### PR TITLE
增加 OpenAI Chat / Responses / Models API 兼容层

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@
 
 - **Dashboard** at `/dashboard/` — manage accounts, view quota, toggle settings
 - **Reverse Proxy** at `/ai` — full Notion AI web UI with pooled accounts
-- **Anthropic Messages API** at `POST /v1/messages` — compatible with Claude Code, Cherry Studio, etc.
+- **API gateway** at `POST /v1/messages`, `POST /v1/chat/completions`, and `POST /v1/responses` — compatible with Anthropic and OpenAI-style clients
 
 ## Quick Start
 
@@ -66,6 +66,9 @@ The account is auto-discovered and hot-loaded — no restart needed.
 export ANTHROPIC_BASE_URL=http://localhost:8081
 export ANTHROPIC_API_KEY=<your-api-key>
 claude  # or any Anthropic-compatible client
+
+export OPENAI_BASE_URL=http://localhost:8081/v1
+export OPENAI_API_KEY=<your-api-key>
 ```
 
 Or download a pre-built binary from [Releases](https://github.com/SleepingBag945/notion-manager/releases) — no Go toolchain required.
@@ -100,14 +103,17 @@ Or download a pre-built binary from [Releases](https://github.com/SleepingBag945
 - Proxy HTML, `/api/*`, static assets, `msgstore`, and WebSocket traffic
 - Rewrite Notion frontend base URLs and strip analytics scripts
 
-### Anthropic-compatible API
+### API compatibility
 
-- `POST /v1/messages`
+- `POST /v1/messages` — Anthropic Messages API
+- `POST /v1/chat/completions` — OpenAI Chat Completions API
+- `POST /v1/responses` — OpenAI Responses API
 - Supports both `Authorization: Bearer <api_key>` and `x-api-key: <api_key>`
 - Streaming and non-streaming responses
-- Anthropic `tools`
-- File content blocks for images, PDFs, and CSVs
+- Anthropic `tools` and OpenAI `tools` / `function_call`
+- File inputs for images, PDFs, and CSVs reuse the existing Notion upload pipeline
 - Default model fallback via `proxy.default_model`
+- `previous_response_id` is intentionally unsupported in `/v1/responses` (stateless bridge)
 
 <p align="center">
   <img src="img/cherry.jpg" alt="Cherry Studio" width="480"><br>

--- a/README.md
+++ b/README.md
@@ -30,11 +30,11 @@
   <img src="img/dashboard.png" alt="Dashboard" width="900">
 </p>
 
-**notion-manager** is a local Notion AI management tool. It builds a multi-account pool, refreshes quota and model state in the background, and exposes three entrypoints:
+**notion-manager** is a local Notion AI management tool. It builds a multi-account pool, refreshes quota and model state in the background, and exposes four entrypoints:
 
 - **Dashboard** at `/dashboard/` — manage accounts, view quota, toggle settings
 - **Reverse Proxy** at `/ai` — full Notion AI web UI with pooled accounts
-- **API gateway** at `POST /v1/messages`, `POST /v1/chat/completions`, and `POST /v1/responses` — compatible with Anthropic and OpenAI-style clients
+- **API gateway** at `POST /v1/messages`, `POST /v1/chat/completions`, `POST /v1/responses`, and `GET /v1/models` (`GET /models` alias) — compatible with Anthropic and OpenAI-style clients
 
 ## Quick Start
 
@@ -108,6 +108,8 @@ Or download a pre-built binary from [Releases](https://github.com/SleepingBag945
 - `POST /v1/messages` — Anthropic Messages API
 - `POST /v1/chat/completions` — OpenAI Chat Completions API
 - `POST /v1/responses` — OpenAI Responses API
+- `GET /v1/models` — OpenAI models API
+- `GET /models` — compatibility alias for `/v1/models`
 - Supports both `Authorization: Bearer <api_key>` and `x-api-key: <api_key>`
 - Streaming and non-streaming responses
 - Anthropic `tools` and OpenAI `tools` / `function_call`

--- a/README_CN.md
+++ b/README_CN.md
@@ -34,7 +34,7 @@
 
 - **Dashboard** `/dashboard/` — 管理账号、查看额度、切换设置
 - **Reverse Proxy** `/ai` — 本地使用完整 Notion AI 页面
-- **Anthropic Messages API** `POST /v1/messages` — 兼容 Claude Code、Cherry Studio 等
+- **API 网关** `POST /v1/messages`、`POST /v1/chat/completions`、`POST /v1/responses` — 同时兼容 Anthropic 与 OpenAI 风格客户端
 
 ## 快速开始
 
@@ -66,6 +66,9 @@ http://localhost:8081/dashboard/
 export ANTHROPIC_BASE_URL=http://localhost:8081
 export ANTHROPIC_API_KEY=<your-api-key>
 claude  # 或任何 Anthropic 兼容客户端
+
+export OPENAI_BASE_URL=http://localhost:8081/v1
+export OPENAI_API_KEY=<your-api-key>
 ```
 
 也可以从 [Releases](https://github.com/SleepingBag945/notion-manager/releases) 下载预编译二进制，无需 Go 工具链。
@@ -100,14 +103,17 @@ claude  # 或任何 Anthropic 兼容客户端
 - 转发 Notion HTML、`/api/*`、静态资源、`msgstore` 和 WebSocket
 - 会动态改写 `CONFIG.domainBaseUrl`，并过滤分析脚本
 
-### 4. Anthropic 协议兼容 API
+### 4. API 协议兼容层
 
-- 提供 `POST /v1/messages`
+- `POST /v1/messages` — Anthropic Messages API
+- `POST /v1/chat/completions` — OpenAI Chat Completions API
+- `POST /v1/responses` — OpenAI Responses API
 - 同时支持 `Authorization: Bearer <api_key>` 和 `x-api-key: <api_key>`
 - 支持流式与非流式响应
-- 支持 Anthropic `tools`
-- 支持图片、PDF、CSV 文件内容块，自动走 Notion 上传链路
+- 同时支持 Anthropic `tools` 与 OpenAI `tools` / `function_call`
+- 图片、PDF、CSV 文件输入会继续复用现有 Notion 上传链路
 - 请求里未指定 `model` 时，自动回退到 `proxy.default_model`
+- `/v1/responses` 暂不支持 `previous_response_id`（当前实现是无状态桥接）
 
 <p align="center">
   <img src="img/cherry.jpg" alt="Cherry Studio" width="480"><br>

--- a/README_CN.md
+++ b/README_CN.md
@@ -30,11 +30,11 @@
   <img src="img/dashboard.png" alt="Dashboard" width="900">
 </p>
 
-**notion-manager** 是一个本地运行的 Notion AI 管理工具。构建多账号池，后台自动刷新额度与模型，对外提供三个入口：
+**notion-manager** 是一个本地运行的 Notion AI 管理工具。构建多账号池，后台自动刷新额度与模型，对外提供四个入口：
 
 - **Dashboard** `/dashboard/` — 管理账号、查看额度、切换设置
 - **Reverse Proxy** `/ai` — 本地使用完整 Notion AI 页面
-- **API 网关** `POST /v1/messages`、`POST /v1/chat/completions`、`POST /v1/responses` — 同时兼容 Anthropic 与 OpenAI 风格客户端
+- **API 网关** `POST /v1/messages`、`POST /v1/chat/completions`、`POST /v1/responses`、`GET /v1/models`（`GET /models` 为兼容别名）— 同时兼容 Anthropic 与 OpenAI 风格客户端
 
 ## 快速开始
 
@@ -108,6 +108,8 @@ export OPENAI_API_KEY=<your-api-key>
 - `POST /v1/messages` — Anthropic Messages API
 - `POST /v1/chat/completions` — OpenAI Chat Completions API
 - `POST /v1/responses` — OpenAI Responses API
+- `GET /v1/models` — OpenAI Models API
+- `GET /models` — `/v1/models` 的兼容别名
 - 同时支持 `Authorization: Bearer <api_key>` 和 `x-api-key: <api_key>`
 - 支持流式与非流式响应
 - 同时支持 Anthropic `tools` 与 OpenAI `tools` / `function_call`

--- a/cmd/notion-manager/main.go
+++ b/cmd/notion-manager/main.go
@@ -128,8 +128,10 @@ func main() {
 
 	mux := http.NewServeMux()
 
-	// Anthropic Messages API endpoint (only supported format)
+	// Anthropic + OpenAI-compatible API endpoints
 	mux.HandleFunc("/v1/messages", proxy.HandleAnthropicMessages(pool))
+	mux.HandleFunc("/v1/chat/completions", proxy.HandleOpenAIChatCompletions(pool))
+	mux.HandleFunc("/v1/responses", proxy.HandleOpenAIResponses(pool))
 
 	// Health check with quota details
 	mux.HandleFunc("/health", proxy.HandleHealth(pool))
@@ -169,7 +171,9 @@ func main() {
 	log.Printf("Endpoints:")
 	log.Printf("  GET  /dashboard/    (Dashboard UI)")
 	log.Printf("  GET  /proxy/start   (Open proxy for account)")
-	log.Printf("  POST /v1/messages   (Anthropic API)")
+	log.Printf("  POST /v1/messages            (Anthropic Messages API)")
+	log.Printf("  POST /v1/chat/completions    (OpenAI Chat Completions API)")
+	log.Printf("  POST /v1/responses           (OpenAI Responses API)")
 	log.Printf("  GET  /health")
 	log.Printf("  GET  /admin/accounts")
 	log.Printf("  GET  /admin/models")

--- a/cmd/notion-manager/main.go
+++ b/cmd/notion-manager/main.go
@@ -10,6 +10,78 @@ import (
 	"notion-manager/internal/proxy"
 )
 
+func requiresAPIKey(path string) bool {
+	return path == "/models" || strings.HasPrefix(path, "/v1/")
+}
+
+func apiKeyAuthMiddleware(apiKey string, next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !requiresAPIKey(r.URL.Path) {
+			next.ServeHTTP(w, r)
+			return
+		}
+
+		var key string
+		if bearer := r.Header.Get("Authorization"); bearer != "" {
+			key = strings.TrimPrefix(bearer, "Bearer ")
+			if key == bearer {
+				key = ""
+			}
+		}
+		if key == "" {
+			key = r.Header.Get("x-api-key")
+		}
+		if key == "" {
+			http.Error(w, `{"error":{"message":"missing api key, use 'Authorization: Bearer <key>' or 'x-api-key: <key>'","type":"auth_error"}}`, http.StatusUnauthorized)
+			return
+		}
+		if key != apiKey {
+			http.Error(w, `{"error":{"message":"invalid api key","type":"auth_error"}}`, http.StatusUnauthorized)
+			return
+		}
+		next.ServeHTTP(w, r)
+	})
+}
+
+func newMux(pool *proxy.AccountPool, accountsDir string, apiKey string, dashAuth *proxy.DashboardAuth) *http.ServeMux {
+	mux := http.NewServeMux()
+
+	// Anthropic + OpenAI-compatible API endpoints
+	mux.HandleFunc("/v1/messages", proxy.HandleAnthropicMessages(pool))
+	mux.HandleFunc("/v1/chat/completions", proxy.HandleOpenAIChatCompletions(pool))
+	mux.HandleFunc("/v1/responses", proxy.HandleOpenAIResponses(pool))
+	mux.HandleFunc("/v1/models", proxy.HandlePublicModels(pool))
+	mux.HandleFunc("/models", proxy.HandlePublicModels(pool))
+
+	// Health check with quota details
+	mux.HandleFunc("/health", proxy.HandleHealth(pool))
+
+	// Admin API endpoints
+	mux.HandleFunc("/admin/accounts", proxy.HandleAdminAccounts(pool, dashAuth))
+	mux.HandleFunc("/admin/accounts/add", proxy.HandleAddAccount(pool, accountsDir, dashAuth))
+	mux.HandleFunc("/admin/accounts/delete", proxy.HandleDeleteAccount(pool, accountsDir, dashAuth))
+	mux.HandleFunc("/admin/models", proxy.HandleAdminModels(pool, dashAuth))
+	mux.HandleFunc("/admin/refresh", proxy.HandleAdminRefresh(pool, accountsDir, dashAuth))
+	mux.HandleFunc("/admin/settings", proxy.HandleAdminSettings("config.yaml", dashAuth))
+
+	// Dashboard (React SPA with embedded API key + auth)
+	mux.Handle("/dashboard/", proxy.HandleDashboard(apiKey, dashAuth))
+	mux.HandleFunc("/dashboard", func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, "/dashboard/", http.StatusMovedPermanently)
+	})
+
+	// Proxy start: create targeted session for a specific account (requires dashboard auth)
+	rp := proxy.NewReverseProxy(pool)
+	mux.HandleFunc("/proxy/start", proxy.HandleProxyStart(pool, rp, dashAuth))
+
+	// Catch-all: reverse proxy for paths with valid np_session, 404 for everything else
+	mux.Handle("/", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		rp.ServeHTTP(w, r)
+	}))
+
+	return mux
+}
+
 func main() {
 	// Load configuration: config.yaml > env > defaults
 	cfg, err := proxy.LoadConfig("config.yaml")
@@ -90,78 +162,10 @@ func main() {
 		})
 	}
 
-	// API Key auth middleware
-	// Supports both OpenAI format (Authorization: Bearer <key>) and Anthropic format (x-api-key: <key>)
 	apiKey := cfg.Server.ApiKey
-	auth := func(next http.Handler) http.Handler {
-		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			// Skip auth for health check, static assets, and SPA routes
-			// API routes (/v1/*, /admin/accounts, /admin/models) still require auth
-			isAPI := strings.HasPrefix(r.URL.Path, "/v1/")
-			if !isAPI {
-				next.ServeHTTP(w, r)
-				return
-			}
-			// Try OpenAI format: Authorization: Bearer <key>
-			var key string
-			if bearer := r.Header.Get("Authorization"); bearer != "" {
-				key = strings.TrimPrefix(bearer, "Bearer ")
-				if key == bearer {
-					key = "" // "Bearer " prefix was missing
-				}
-			}
-			// Try Anthropic format: x-api-key: <key>
-			if key == "" {
-				key = r.Header.Get("x-api-key")
-			}
-			if key == "" {
-				http.Error(w, `{"error":{"message":"missing api key, use 'Authorization: Bearer <key>' or 'x-api-key: <key>'","type":"auth_error"}}`, http.StatusUnauthorized)
-				return
-			}
-			if key != apiKey {
-				http.Error(w, `{"error":{"message":"invalid api key","type":"auth_error"}}`, http.StatusUnauthorized)
-				return
-			}
-			next.ServeHTTP(w, r)
-		})
-	}
-
-	mux := http.NewServeMux()
-
-	// Anthropic + OpenAI-compatible API endpoints
-	mux.HandleFunc("/v1/messages", proxy.HandleAnthropicMessages(pool))
-	mux.HandleFunc("/v1/chat/completions", proxy.HandleOpenAIChatCompletions(pool))
-	mux.HandleFunc("/v1/responses", proxy.HandleOpenAIResponses(pool))
-
-	// Health check with quota details
-	mux.HandleFunc("/health", proxy.HandleHealth(pool))
-
 	// Dashboard auth (admin password from config.yaml)
 	dashAuth := proxy.NewDashboardAuth(cfg.Server.AdminPassword, apiKey)
-
-	// Admin API endpoints
-	mux.HandleFunc("/admin/accounts", proxy.HandleAdminAccounts(pool, dashAuth))
-	mux.HandleFunc("/admin/accounts/add", proxy.HandleAddAccount(pool, accountsDir, dashAuth))
-	mux.HandleFunc("/admin/accounts/delete", proxy.HandleDeleteAccount(pool, accountsDir, dashAuth))
-	mux.HandleFunc("/admin/models", proxy.HandleAdminModels(pool, dashAuth))
-	mux.HandleFunc("/admin/refresh", proxy.HandleAdminRefresh(pool, accountsDir, dashAuth))
-	mux.HandleFunc("/admin/settings", proxy.HandleAdminSettings("config.yaml", dashAuth))
-
-	// Dashboard (React SPA with embedded API key + auth)
-	mux.Handle("/dashboard/", proxy.HandleDashboard(apiKey, dashAuth))
-	mux.HandleFunc("/dashboard", func(w http.ResponseWriter, r *http.Request) {
-		http.Redirect(w, r, "/dashboard/", http.StatusMovedPermanently)
-	})
-
-	// Proxy start: create targeted session for a specific account (requires dashboard auth)
-	rp := proxy.NewReverseProxy(pool)
-	mux.HandleFunc("/proxy/start", proxy.HandleProxyStart(pool, rp, dashAuth))
-
-	// Catch-all: reverse proxy for paths with valid np_session, 404 for everything else
-	mux.Handle("/", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		// Reverse proxy routes require np_session (created via /proxy/start)
-		rp.ServeHTTP(w, r)
-	}))
+	mux := newMux(pool, accountsDir, apiKey, dashAuth)
 
 	log.Printf("=== notion-manager ===")
 	log.Printf("Listening on :%s", port)
@@ -171,16 +175,18 @@ func main() {
 	log.Printf("Endpoints:")
 	log.Printf("  GET  /dashboard/    (Dashboard UI)")
 	log.Printf("  GET  /proxy/start   (Open proxy for account)")
-	log.Printf("  POST /v1/messages            (Anthropic Messages API)")
-	log.Printf("  POST /v1/chat/completions    (OpenAI Chat Completions API)")
-	log.Printf("  POST /v1/responses           (OpenAI Responses API)")
+	log.Printf("  POST /v1/messages           (Anthropic Messages API)")
+	log.Printf("  POST /v1/chat/completions   (OpenAI Chat Completions API)")
+	log.Printf("  POST /v1/responses          (OpenAI Responses API)")
+	log.Printf("  GET  /v1/models             (OpenAI models API)")
+	log.Printf("  GET  /models                (OpenAI models alias)")
 	log.Printf("  GET  /health")
 	log.Printf("  GET  /admin/accounts")
 	log.Printf("  GET  /admin/models")
 	log.Printf("  GET  /admin/settings  (search settings)")
 	log.Printf("  GET  /ai            (Reverse Proxy → notion.so)")
 
-	if err := http.ListenAndServe(":"+port, cors(auth(mux))); err != nil {
+	if err := http.ListenAndServe(":"+port, cors(apiKeyAuthMiddleware(apiKey, mux))); err != nil {
 		log.Fatalf("Server error: %v", err)
 	}
 }

--- a/cmd/notion-manager/main_test.go
+++ b/cmd/notion-manager/main_test.go
@@ -1,0 +1,133 @@
+package main
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"notion-manager/internal/proxy"
+)
+
+func TestRequiresAPIKey(t *testing.T) {
+	tests := []struct {
+		path string
+		want bool
+	}{
+		{path: "/v1/messages", want: true},
+		{path: "/v1/chat/completions", want: true},
+		{path: "/v1/responses", want: true},
+		{path: "/v1/models", want: true},
+		{path: "/models", want: true},
+		{path: "/health", want: false},
+		{path: "/dashboard/", want: false},
+	}
+
+	for _, tc := range tests {
+		if got := requiresAPIKey(tc.path); got != tc.want {
+			t.Fatalf("requiresAPIKey(%q) = %v, want %v", tc.path, got, tc.want)
+		}
+	}
+}
+
+func TestAPIKeyAuthMiddleware_ProtectsModelsRoutes(t *testing.T) {
+	handler := apiKeyAuthMiddleware("sk-test", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNoContent)
+	}))
+
+	tests := []struct {
+		name    string
+		path    string
+		headers map[string]string
+		want    int
+	}{
+		{name: "models missing key", path: "/models", want: http.StatusUnauthorized},
+		{name: "models wrong key", path: "/models", headers: map[string]string{"Authorization": "Bearer sk-wrong"}, want: http.StatusUnauthorized},
+		{name: "models bearer", path: "/models", headers: map[string]string{"Authorization": "Bearer sk-test"}, want: http.StatusNoContent},
+		{name: "v1 models x-api-key", path: "/v1/models", headers: map[string]string{"x-api-key": "sk-test"}, want: http.StatusNoContent},
+		{name: "chat missing key", path: "/v1/chat/completions", want: http.StatusUnauthorized},
+		{name: "responses x-api-key", path: "/v1/responses", headers: map[string]string{"x-api-key": "sk-test"}, want: http.StatusNoContent},
+		{name: "health no auth", path: "/health", want: http.StatusNoContent},
+	}
+
+	for _, tc := range tests {
+		rec := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodGet, tc.path, nil)
+		for key, value := range tc.headers {
+			req.Header.Set(key, value)
+		}
+
+		handler.ServeHTTP(rec, req)
+
+		if rec.Code != tc.want {
+			t.Fatalf("%s: expected %d, got %d body=%s", tc.name, tc.want, rec.Code, rec.Body.String())
+		}
+	}
+}
+
+func TestNewMux_RegistersModelsRoutes(t *testing.T) {
+	original := cloneConfigModelMap(proxy.DefaultModelMap)
+	proxy.DefaultModelMap = map[string]string{
+		"opus-4.6": "avocado-froyo-medium",
+	}
+	t.Cleanup(func() {
+		proxy.DefaultModelMap = original
+	})
+
+	pool := proxy.NewAccountPool()
+	dashAuth := proxy.NewDashboardAuth("", "sk-test")
+	mux := newMux(pool, "", "sk-test", dashAuth)
+	handler := apiKeyAuthMiddleware("sk-test", mux)
+
+	for _, path := range []string{"/v1/models", "/models"} {
+		rec := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodGet, path, nil)
+		req.Header.Set("Authorization", "Bearer sk-test")
+		handler.ServeHTTP(rec, req)
+
+		if rec.Code != http.StatusOK {
+			t.Fatalf("%s: expected 200, got %d body=%s", path, rec.Code, rec.Body.String())
+		}
+	}
+}
+
+func TestNewMux_RegistersOpenAIRoutes(t *testing.T) {
+	originalConfig := proxy.AppConfig
+	proxy.AppConfig = proxy.DefaultConfig()
+	t.Cleanup(func() {
+		proxy.AppConfig = originalConfig
+	})
+
+	pool := proxy.NewAccountPool()
+	dashAuth := proxy.NewDashboardAuth("", "sk-test")
+	mux := newMux(pool, "", "sk-test", dashAuth)
+	handler := apiKeyAuthMiddleware("sk-test", mux)
+
+	tests := []struct {
+		path string
+		body string
+	}{
+		{path: "/v1/chat/completions", body: `{"messages":[]}`},
+		{path: "/v1/responses", body: `{"input":"ping"}`},
+	}
+
+	for _, tc := range tests {
+		rec := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodPost, tc.path, strings.NewReader(tc.body))
+		req.Header.Set("Authorization", "Bearer sk-test")
+		req.Header.Set("Content-Type", "application/json")
+		handler.ServeHTTP(rec, req)
+
+		if rec.Code == http.StatusNotFound {
+			t.Fatalf("%s: expected registered handler, got 404", tc.path)
+		}
+	}
+}
+
+func cloneConfigModelMap(src map[string]string) map[string]string {
+	dst := make(map[string]string, len(src))
+	for k, v := range src {
+		dst[k] = v
+	}
+	return dst
+}

--- a/docs/api.md
+++ b/docs/api.md
@@ -2,7 +2,17 @@
 
 [← Back to README](../README.md)
 
-## Standard request
+## Supported API shapes
+
+- `POST /v1/messages` — Anthropic Messages API
+- `POST /v1/chat/completions` — OpenAI Chat Completions API
+- `POST /v1/responses` — OpenAI Responses API
+
+All three routes reuse the same multi-account pool, file upload pipeline, tool bridge, and failover logic.
+
+`/v1/responses` is currently stateless, so `previous_response_id` is not supported.
+
+## Anthropic Messages request
 
 `/v1/messages` accepts Anthropic Messages API payloads.
 
@@ -20,6 +30,36 @@ curl http://localhost:3000/v1/messages \
 ```
 
 If `model` is omitted, the service falls back to `proxy.default_model`.
+
+## OpenAI Chat Completions request
+
+```bash
+curl http://localhost:3000/v1/chat/completions \
+  -H "Authorization: Bearer <api_key>" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "gpt-5.4",
+    "messages": [
+      { "role": "user", "content": "Summarize the architecture of notion-manager." }
+    ]
+  }'
+```
+
+Supported request features include `messages`, `stream`, `tools`, `tool_choice`, `response_format`, and inline file/image inputs.
+
+## OpenAI Responses request
+
+```bash
+curl http://localhost:3000/v1/responses \
+  -H "Authorization: Bearer <api_key>" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "gpt-5.4",
+    "input": "List the main subsystems in this project."
+  }'
+```
+
+Supported request features include `input`, `instructions`, `stream`, `tools`, `tool_choice`, `text.format`, and inline file/image inputs.
 
 ## Search overrides
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -7,8 +7,10 @@
 - `POST /v1/messages` — Anthropic Messages API
 - `POST /v1/chat/completions` — OpenAI Chat Completions API
 - `POST /v1/responses` — OpenAI Responses API
+- `GET /v1/models` — OpenAI models API
+- `GET /models` — compatibility alias for `/v1/models`
 
-All three routes reuse the same multi-account pool, file upload pipeline, tool bridge, and failover logic.
+All of these routes reuse the same multi-account pool, file upload pipeline, tool bridge, and failover logic.
 
 `/v1/responses` is currently stateless, so `previous_response_id` is not supported.
 
@@ -30,6 +32,17 @@ curl http://localhost:3000/v1/messages \
 ```
 
 If `model` is omitted, the service falls back to `proxy.default_model`.
+
+## OpenAI Models request
+
+```bash
+curl http://localhost:3000/v1/models \
+  -H "Authorization: Bearer <api_key>"
+```
+
+The response returns normalized friendly model IDs that can be passed back into `/v1/chat/completions`, `/v1/responses`, or `/v1/messages`.
+
+`GET /models` returns the same payload for clients that probe the bare root alias.
 
 ## OpenAI Chat Completions request
 

--- a/docs/api_cn.md
+++ b/docs/api_cn.md
@@ -2,7 +2,17 @@
 
 [← 返回 README](../README_CN.md)
 
-## 基本请求
+## 支持的 API 形态
+
+- `POST /v1/messages` — Anthropic Messages API
+- `POST /v1/chat/completions` — OpenAI Chat Completions API
+- `POST /v1/responses` — OpenAI Responses API
+
+三条路由共用同一套多账号池、文件上传链路、工具桥接和失败切换逻辑。
+
+当前 `/v1/responses` 是无状态桥接，因此暂不支持 `previous_response_id`。
+
+## Anthropic Messages 基本请求
 
 `/v1/messages` 使用 Anthropic Messages API 结构。
 
@@ -20,6 +30,36 @@ curl http://localhost:3000/v1/messages \
 ```
 
 如果不传 `model`，会自动使用 `proxy.default_model`。
+
+## OpenAI Chat Completions 基本请求
+
+```bash
+curl http://localhost:3000/v1/chat/completions \
+  -H "Authorization: Bearer <api_key>" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "gpt-5.4",
+    "messages": [
+      { "role": "user", "content": "请总结 notion-manager 的主要架构。" }
+    ]
+  }'
+```
+
+已支持的常用字段包括 `messages`、`stream`、`tools`、`tool_choice`、`response_format`，以及内联图片 / 文件输入。
+
+## OpenAI Responses 基本请求
+
+```bash
+curl http://localhost:3000/v1/responses \
+  -H "Authorization: Bearer <api_key>" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "gpt-5.4",
+    "input": "列出这个项目的主要子系统。"
+  }'
+```
+
+已支持的常用字段包括 `input`、`instructions`、`stream`、`tools`、`tool_choice`、`text.format`，以及内联图片 / 文件输入。
 
 ## 搜索控制
 

--- a/docs/api_cn.md
+++ b/docs/api_cn.md
@@ -7,8 +7,10 @@
 - `POST /v1/messages` — Anthropic Messages API
 - `POST /v1/chat/completions` — OpenAI Chat Completions API
 - `POST /v1/responses` — OpenAI Responses API
+- `GET /v1/models` — OpenAI Models API
+- `GET /models` — `/v1/models` 的兼容别名
 
-三条路由共用同一套多账号池、文件上传链路、工具桥接和失败切换逻辑。
+这些路由共用同一套多账号池、文件上传链路、工具桥接和失败切换逻辑。
 
 当前 `/v1/responses` 是无状态桥接，因此暂不支持 `previous_response_id`。
 
@@ -30,6 +32,17 @@ curl http://localhost:3000/v1/messages \
 ```
 
 如果不传 `model`，会自动使用 `proxy.default_model`。
+
+## OpenAI Models 基本请求
+
+```bash
+curl http://localhost:3000/v1/models \
+  -H "Authorization: Bearer <api_key>"
+```
+
+返回结果里的模型 ID 都是归一化后的友好名称，可直接继续传给 `/v1/chat/completions`、`/v1/responses` 或 `/v1/messages`。
+
+`GET /models` 会返回相同 payload，兼容某些直接探测根路径的客户端。
 
 ## OpenAI Chat Completions 基本请求
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -32,6 +32,8 @@ environment variables > config.yaml > code defaults
 | --- | --- | --- |
 | `GET /health` | Health and account pool summary | None |
 | `POST /v1/messages` | Anthropic Messages API | API key |
+| `POST /v1/chat/completions` | OpenAI Chat Completions API | API key |
+| `POST /v1/responses` | OpenAI Responses API | API key |
 | `GET /dashboard/` | Dashboard UI | Dashboard login |
 | `GET /proxy/start` | Create a targeted proxy session | Dashboard login |
 | `GET /ai` | Local Notion Web proxy entry | `np_session` |

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -14,7 +14,7 @@ environment variables > config.yaml > code defaults
 | --- | --- | --- | --- |
 | `server.port` | `3000` | `8081` | This README uses the checked-in sample port |
 | `server.accounts_dir` | `accounts` | `accounts` | Account JSON directory |
-| `server.api_key` | empty | auto-generated | Used for API-key protected endpoints |
+| `server.api_key` | empty | auto-generated | Used for `/v1/messages`, `/v1/chat/completions`, `/v1/responses`, `/v1/models`, `/models`, and other API-key protected endpoints |
 | `server.admin_password` | empty | auto-generated | Auto-generated if empty; hashed on first startup |
 | `server.debug_logging` | `true` | `true` | High-volume debug logging |
 | `proxy.default_model` | `opus-4.6` | `opus-4.6` | Fallback model |
@@ -34,6 +34,8 @@ environment variables > config.yaml > code defaults
 | `POST /v1/messages` | Anthropic Messages API | API key |
 | `POST /v1/chat/completions` | OpenAI Chat Completions API | API key |
 | `POST /v1/responses` | OpenAI Responses API | API key |
+| `GET /v1/models` | OpenAI models API | API key |
+| `GET /models` | Compatibility alias for `/v1/models` | API key |
 | `GET /dashboard/` | Dashboard UI | Dashboard login |
 | `GET /proxy/start` | Create a targeted proxy session | Dashboard login |
 | `GET /ai` | Local Notion Web proxy entry | `np_session` |

--- a/docs/configuration_cn.md
+++ b/docs/configuration_cn.md
@@ -41,6 +41,8 @@ export ENABLE_WORKSPACE_SEARCH=false
 | --- | --- | --- |
 | `GET /health` | 健康检查与账号池摘要 | 无 |
 | `POST /v1/messages` | Anthropic Messages API | API Key |
+| `POST /v1/chat/completions` | OpenAI Chat Completions API | API Key |
+| `POST /v1/responses` | OpenAI Responses API | API Key |
 | `GET /dashboard/` | 管理面板 | Dashboard 登录 |
 | `GET /proxy/start` | 为选定账号创建代理会话 | Dashboard 登录 |
 | `GET /ai` | Notion Web 代理入口 | `np_session` |

--- a/docs/configuration_cn.md
+++ b/docs/configuration_cn.md
@@ -14,7 +14,7 @@
 | --- | --- | --- | --- |
 | `server.port` | `3000` | `8081` | 文档示例默认按仓库样例的 `3000` 编写 |
 | `server.accounts_dir` | `accounts` | `accounts` | 账号 JSON 目录 |
-| `server.api_key` | 空 | 自动生成 | 仅用于 `/v1/messages` 等 API Key 保护接口 |
+| `server.api_key` | 空 | 自动生成 | 用于 `/v1/messages`、`/v1/chat/completions`、`/v1/responses`、`/v1/models`、`/models` 等 API Key 保护接口 |
 | `server.admin_password` | 空 | 自动生成 | 留空时自动生成；首次启动后哈希回写 |
 | `server.debug_logging` | `true` | `true` | 控制高频调试日志 |
 | `proxy.default_model` | `opus-4.6` | `opus-4.6` | 请求未传 `model` 时的回退模型 |
@@ -43,6 +43,8 @@ export ENABLE_WORKSPACE_SEARCH=false
 | `POST /v1/messages` | Anthropic Messages API | API Key |
 | `POST /v1/chat/completions` | OpenAI Chat Completions API | API Key |
 | `POST /v1/responses` | OpenAI Responses API | API Key |
+| `GET /v1/models` | OpenAI Models API | API Key |
+| `GET /models` | `/v1/models` 的兼容别名 | API Key |
 | `GET /dashboard/` | 管理面板 | Dashboard 登录 |
 | `GET /proxy/start` | 为选定账号创建代理会话 | Dashboard 登录 |
 | `GET /ai` | Notion Web 代理入口 | `np_session` |

--- a/internal/proxy/handler.go
+++ b/internal/proxy/handler.go
@@ -5,10 +5,25 @@ import (
 	"log"
 	"net/http"
 	"os"
+	"sort"
 	"strings"
 
 	"gopkg.in/yaml.v3"
 )
+
+const publicModelCreatedAt = int64(1735689600)
+
+type publicModelResponse struct {
+	Object string        `json:"object"`
+	Data   []publicModel `json:"data"`
+}
+
+type publicModel struct {
+	ID      string `json:"id"`
+	Object  string `json:"object"`
+	Created int64  `json:"created"`
+	OwnedBy string `json:"owned_by"`
+}
 
 // HandleHealth returns an HTTP handler for the /health endpoint
 func HandleHealth(pool *AccountPool) http.HandlerFunc {
@@ -22,6 +37,74 @@ func HandleHealth(pool *AccountPool) http.HandlerFunc {
 		}
 		json.NewEncoder(w).Encode(resp)
 	}
+}
+
+// HandlePublicModels returns an OpenAI-compatible models list for API clients.
+func HandlePublicModels(pool *AccountPool) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if r.Method != http.MethodGet {
+			w.Header().Set("Allow", http.MethodGet)
+			http.Error(w, `{"error":{"message":"method not allowed","type":"invalid_request_error"}}`, http.StatusMethodNotAllowed)
+			return
+		}
+
+		resp := publicModelResponse{
+			Object: "list",
+			Data:   buildPublicModels(pool.AllModels()),
+		}
+		json.NewEncoder(w).Encode(resp)
+	}
+}
+
+func buildPublicModels(models []ModelEntry) []publicModel {
+	seen := make(map[string]bool, len(models))
+	items := make([]publicModel, 0, len(models))
+	for _, model := range models {
+		id := publicModelID(model)
+		if id == "" || seen[id] {
+			continue
+		}
+		seen[id] = true
+		items = append(items, publicModel{
+			ID:      id,
+			Object:  "model",
+			Created: publicModelCreatedAt,
+			OwnedBy: "notion-manager",
+		})
+	}
+
+	sort.Slice(items, func(i, j int) bool {
+		return items[i].ID < items[j].ID
+	})
+	return items
+}
+
+func publicModelID(model ModelEntry) string {
+	if normalized := normalizeModelName(model.Name); normalized != "" {
+		return normalized
+	}
+	return friendlyModelNameByInternalID(model.ID)
+}
+
+func friendlyModelNameByInternalID(id string) string {
+	trimmed := strings.TrimSpace(id)
+	if trimmed == "" {
+		return ""
+	}
+
+	candidates := make([]string, 0, 1)
+	for friendly, internalID := range DefaultModelMap {
+		if internalID == trimmed {
+			candidates = append(candidates, friendly)
+		}
+	}
+	if len(candidates) == 0 {
+		return ""
+	}
+
+	sort.Strings(candidates)
+	return candidates[0]
 }
 
 // HandleAdminAccounts returns detailed account info including models, quota, and status

--- a/internal/proxy/handler_models_test.go
+++ b/internal/proxy/handler_models_test.go
@@ -1,0 +1,124 @@
+package proxy
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"testing"
+)
+
+func TestHandlePublicModels_UsesPoolModelsAndNormalizesIDs(t *testing.T) {
+	original := cloneModelMap(DefaultModelMap)
+	DefaultModelMap = map[string]string{
+		"opus-4.6": "avocado-froyo-medium",
+		"gpt-5.4":  "oval-kumquat-medium",
+	}
+	t.Cleanup(func() {
+		DefaultModelMap = original
+	})
+
+	pool := NewAccountPool()
+	pool.accounts = []*Account{
+		{
+			Models: []ModelEntry{
+				{Name: "GPT 5.4", ID: "oval-kumquat-medium"},
+				{Name: "Opus 4.6", ID: "avocado-froyo-medium"},
+				{Name: "GPT 5.4", ID: "oval-kumquat-medium"},
+			},
+		},
+	}
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/v1/models", nil)
+	HandlePublicModels(pool).ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+
+	var resp publicModelResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+
+	if resp.Object != "list" {
+		t.Fatalf("expected object=list, got %q", resp.Object)
+	}
+
+	gotIDs := make([]string, 0, len(resp.Data))
+	for _, item := range resp.Data {
+		if item.Object != "model" {
+			t.Fatalf("expected object=model, got %q", item.Object)
+		}
+		if item.Created != publicModelCreatedAt {
+			t.Fatalf("expected created=%d, got %d", publicModelCreatedAt, item.Created)
+		}
+		if item.OwnedBy != "notion-manager" {
+			t.Fatalf("expected owned_by notion-manager, got %q", item.OwnedBy)
+		}
+		gotIDs = append(gotIDs, item.ID)
+	}
+
+	wantIDs := []string{"gpt-5.4", "opus-4.6"}
+	if !reflect.DeepEqual(gotIDs, wantIDs) {
+		t.Fatalf("unexpected model ids: got %v want %v", gotIDs, wantIDs)
+	}
+}
+
+func TestHandlePublicModels_FallsBackToDefaultModelMap(t *testing.T) {
+	original := cloneModelMap(DefaultModelMap)
+	DefaultModelMap = map[string]string{
+		"gemini-2.5-flash": "vertex-gemini-2.5-flash",
+		"sonnet-4.6":       "almond-croissant-low",
+	}
+	t.Cleanup(func() {
+		DefaultModelMap = original
+	})
+
+	pool := NewAccountPool()
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/models", nil)
+	HandlePublicModels(pool).ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+
+	var resp publicModelResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+
+	gotIDs := make([]string, 0, len(resp.Data))
+	for _, item := range resp.Data {
+		gotIDs = append(gotIDs, item.ID)
+	}
+
+	wantIDs := []string{"gemini-2.5-flash", "sonnet-4.6"}
+	if !reflect.DeepEqual(gotIDs, wantIDs) {
+		t.Fatalf("unexpected fallback models: got %v want %v", gotIDs, wantIDs)
+	}
+}
+
+func TestHandlePublicModels_MethodNotAllowed(t *testing.T) {
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/v1/models", nil)
+	HandlePublicModels(NewAccountPool()).ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusMethodNotAllowed {
+		t.Fatalf("expected 405, got %d: %s", rec.Code, rec.Body.String())
+	}
+	if allow := rec.Header().Get("Allow"); allow != http.MethodGet {
+		t.Fatalf("expected Allow=GET, got %q", allow)
+	}
+}
+
+func cloneModelMap(src map[string]string) map[string]string {
+	dst := make(map[string]string, len(src))
+	for k, v := range src {
+		dst[k] = v
+	}
+	return dst
+}

--- a/internal/proxy/openai.go
+++ b/internal/proxy/openai.go
@@ -1,0 +1,1835 @@
+package proxy
+
+import (
+	"bytes"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"io"
+	"mime"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"strings"
+	"sync"
+	"time"
+)
+
+// ========== OpenAI Chat Completions / Responses compatibility ==========
+
+type OpenAIErrorResponse struct {
+	Error OpenAIError `json:"error"`
+}
+
+type OpenAIError struct {
+	Message string      `json:"message"`
+	Type    string      `json:"type,omitempty"`
+	Param   string      `json:"param,omitempty"`
+	Code    interface{} `json:"code,omitempty"`
+}
+
+type OpenAIFunctionDefinition struct {
+	Name        string      `json:"name"`
+	Description string      `json:"description,omitempty"`
+	Parameters  interface{} `json:"parameters,omitempty"`
+	Strict      bool        `json:"strict,omitempty"`
+}
+
+type OpenAITool struct {
+	Type        string                    `json:"type"`
+	Name        string                    `json:"name,omitempty"`
+	Description string                    `json:"description,omitempty"`
+	Parameters  interface{}               `json:"parameters,omitempty"`
+	Strict      bool                      `json:"strict,omitempty"`
+	Function    *OpenAIFunctionDefinition `json:"function,omitempty"`
+}
+
+type OpenAIChatToolCallFunction struct {
+	Name      string `json:"name"`
+	Arguments string `json:"arguments"`
+}
+
+type OpenAIChatToolCall struct {
+	ID       string                     `json:"id"`
+	Type     string                     `json:"type"`
+	Function OpenAIChatToolCallFunction `json:"function"`
+}
+
+type OpenAIChatMessage struct {
+	Role       string               `json:"role"`
+	Content    interface{}          `json:"content,omitempty"`
+	Name       string               `json:"name,omitempty"`
+	ToolCallID string               `json:"tool_call_id,omitempty"`
+	ToolCalls  []OpenAIChatToolCall `json:"tool_calls,omitempty"`
+}
+
+type OpenAIJSONSchemaConfig struct {
+	Name        string      `json:"name,omitempty"`
+	Description string      `json:"description,omitempty"`
+	Schema      interface{} `json:"schema,omitempty"`
+	Strict      bool        `json:"strict,omitempty"`
+}
+
+type OpenAIChatResponseFormat struct {
+	Type       string                  `json:"type,omitempty"`
+	JSONSchema *OpenAIJSONSchemaConfig `json:"json_schema,omitempty"`
+}
+
+type OpenAIChatStreamOptions struct {
+	IncludeUsage bool `json:"include_usage,omitempty"`
+}
+
+type OpenAIChatCompletionRequest struct {
+	Model               string                     `json:"model"`
+	Messages            []OpenAIChatMessage        `json:"messages"`
+	Stream              bool                       `json:"stream,omitempty"`
+	Tools               []OpenAITool               `json:"tools,omitempty"`
+	ToolChoice          interface{}                `json:"tool_choice,omitempty"`
+	ResponseFormat      *OpenAIChatResponseFormat  `json:"response_format,omitempty"`
+	StreamOptions       *OpenAIChatStreamOptions   `json:"stream_options,omitempty"`
+	Temperature         *float64                   `json:"temperature,omitempty"`
+	TopP                *float64                   `json:"top_p,omitempty"`
+	MaxTokens           int                        `json:"max_tokens,omitempty"`
+	MaxCompletionTokens int                        `json:"max_completion_tokens,omitempty"`
+	Functions           []OpenAIFunctionDefinition `json:"functions,omitempty"`
+	FunctionCall        interface{}                `json:"function_call,omitempty"`
+	Metadata            map[string]interface{}     `json:"metadata,omitempty"`
+	N                   int                        `json:"n,omitempty"`
+}
+
+type OpenAIChatCompletionChoice struct {
+	Index        int                    `json:"index"`
+	Message      map[string]interface{} `json:"message"`
+	FinishReason *string                `json:"finish_reason"`
+}
+
+type OpenAIChatCompletionResponse struct {
+	ID      string                       `json:"id"`
+	Object  string                       `json:"object"`
+	Created int64                        `json:"created"`
+	Model   string                       `json:"model"`
+	Choices []OpenAIChatCompletionChoice `json:"choices"`
+	Usage   map[string]int               `json:"usage,omitempty"`
+}
+
+type OpenAIResponsesTextConfig struct {
+	Format *OpenAIChatResponseFormat `json:"format,omitempty"`
+}
+
+type OpenAIResponsesRequest struct {
+	Model              string                     `json:"model"`
+	Input              interface{}                `json:"input"`
+	Stream             bool                       `json:"stream,omitempty"`
+	Tools              []OpenAITool               `json:"tools,omitempty"`
+	ToolChoice         interface{}                `json:"tool_choice,omitempty"`
+	Instructions       string                     `json:"instructions,omitempty"`
+	Text               *OpenAIResponsesTextConfig `json:"text,omitempty"`
+	Temperature        *float64                   `json:"temperature,omitempty"`
+	TopP               *float64                   `json:"top_p,omitempty"`
+	MaxOutputTokens    int                        `json:"max_output_tokens,omitempty"`
+	PreviousResponseID string                     `json:"previous_response_id,omitempty"`
+	Metadata           map[string]interface{}     `json:"metadata,omitempty"`
+}
+
+type anthropicInvocationError struct {
+	Status  int
+	Message string
+	Type    string
+}
+
+type anthropicSSEFrame struct {
+	Event string
+	Data  json.RawMessage
+}
+
+type anthropicStreamBridgeWriter struct {
+	header  http.Header
+	status  int
+	mu      sync.Mutex
+	buffer  strings.Builder
+	errBody bytes.Buffer
+	frames  chan string
+}
+
+func newAnthropicStreamBridgeWriter() *anthropicStreamBridgeWriter {
+	return &anthropicStreamBridgeWriter{
+		header: make(http.Header),
+		frames: make(chan string, 64),
+	}
+}
+
+func (w *anthropicStreamBridgeWriter) Header() http.Header {
+	return w.header
+}
+
+func (w *anthropicStreamBridgeWriter) WriteHeader(statusCode int) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	if w.status == 0 {
+		w.status = statusCode
+	}
+}
+
+func (w *anthropicStreamBridgeWriter) Write(p []byte) (int, error) {
+	w.mu.Lock()
+	if w.status == 0 {
+		w.status = http.StatusOK
+	}
+	if w.status != http.StatusOK {
+		_, _ = w.errBody.Write(p)
+		w.mu.Unlock()
+		return len(p), nil
+	}
+	_, _ = w.buffer.WriteString(string(p))
+	var frames []string
+	for {
+		buf := w.buffer.String()
+		idx := strings.Index(buf, "\n\n")
+		if idx < 0 {
+			break
+		}
+		frame := buf[:idx]
+		rest := buf[idx+2:]
+		w.buffer.Reset()
+		w.buffer.WriteString(rest)
+		frames = append(frames, frame)
+	}
+	w.mu.Unlock()
+
+	for _, frame := range frames {
+		w.frames <- frame
+	}
+	return len(p), nil
+}
+
+func (w *anthropicStreamBridgeWriter) Flush() {}
+
+func (w *anthropicStreamBridgeWriter) Close() {
+	w.mu.Lock()
+	leftover := strings.TrimSpace(w.buffer.String())
+	w.buffer.Reset()
+	w.mu.Unlock()
+	if leftover != "" {
+		w.frames <- leftover
+	}
+	close(w.frames)
+}
+
+func (w *anthropicStreamBridgeWriter) Status() int {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	if w.status == 0 {
+		return http.StatusOK
+	}
+	return w.status
+}
+
+func (w *anthropicStreamBridgeWriter) ErrorBody() []byte {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	return append([]byte(nil), w.errBody.Bytes()...)
+}
+
+type openAIChatStreamToolState struct {
+	ToolIndex int
+	CallID    string
+	Name      string
+}
+
+type openAIChatStreamTranscoder struct {
+	w            http.ResponseWriter
+	flusher      http.Flusher
+	id           string
+	model        string
+	created      int64
+	includeUsage bool
+	inputTokens  int
+	outputTokens int
+	sentRole     bool
+	done         bool
+	nextTool     int
+	toolBlocks   map[int]openAIChatStreamToolState
+}
+
+func newOpenAIChatStreamTranscoder(w http.ResponseWriter, flusher http.Flusher, id, model string, created int64, includeUsage bool) *openAIChatStreamTranscoder {
+	return &openAIChatStreamTranscoder{
+		w:            w,
+		flusher:      flusher,
+		id:           id,
+		model:        model,
+		created:      created,
+		includeUsage: includeUsage,
+		toolBlocks:   make(map[int]openAIChatStreamToolState),
+	}
+}
+
+func (t *openAIChatStreamTranscoder) emitChunk(delta map[string]interface{}, finishReason *string, usage map[string]int) error {
+	payload := map[string]interface{}{
+		"id":      t.id,
+		"object":  "chat.completion.chunk",
+		"created": t.created,
+		"model":   t.model,
+		"choices": []map[string]interface{}{{
+			"index":         0,
+			"delta":         delta,
+			"finish_reason": finishReason,
+		}},
+	}
+	if usage != nil {
+		payload["usage"] = usage
+	}
+	return sendOpenAISSE(t.w, t.flusher, payload)
+}
+
+func (t *openAIChatStreamTranscoder) emitUsageChunk() error {
+	if !t.includeUsage {
+		return nil
+	}
+	payload := map[string]interface{}{
+		"id":      t.id,
+		"object":  "chat.completion.chunk",
+		"created": t.created,
+		"model":   t.model,
+		"choices": []interface{}{},
+		"usage": map[string]int{
+			"prompt_tokens":     t.inputTokens,
+			"completion_tokens": t.outputTokens,
+			"total_tokens":      t.inputTokens + t.outputTokens,
+		},
+	}
+	return sendOpenAISSE(t.w, t.flusher, payload)
+}
+
+func (t *openAIChatStreamTranscoder) HandleFrame(frame anthropicSSEFrame) error {
+	var payload map[string]interface{}
+	if len(frame.Data) > 0 {
+		if err := json.Unmarshal(frame.Data, &payload); err != nil {
+			return err
+		}
+	}
+
+	switch frame.Event {
+	case "message_start":
+		if message, ok := payload["message"].(map[string]interface{}); ok {
+			if usage, ok := message["usage"].(map[string]interface{}); ok {
+				t.inputTokens = intValue(usage["input_tokens"])
+			}
+		}
+		if !t.sentRole {
+			t.sentRole = true
+			return t.emitChunk(map[string]interface{}{"role": "assistant"}, nil, nil)
+		}
+	case "content_block_start":
+		index := intValue(payload["index"])
+		block, _ := payload["content_block"].(map[string]interface{})
+		if blockType, _ := block["type"].(string); blockType == "tool_use" {
+			state := openAIChatStreamToolState{
+				ToolIndex: t.nextTool,
+				CallID:    stringValue(block["id"]),
+				Name:      stringValue(block["name"]),
+			}
+			t.nextTool++
+			t.toolBlocks[index] = state
+			return t.emitChunk(map[string]interface{}{
+				"tool_calls": []map[string]interface{}{{
+					"index": state.ToolIndex,
+					"id":    state.CallID,
+					"type":  "function",
+					"function": map[string]interface{}{
+						"name":      state.Name,
+						"arguments": "",
+					},
+				}},
+			}, nil, nil)
+		}
+	case "content_block_delta":
+		index := intValue(payload["index"])
+		delta, _ := payload["delta"].(map[string]interface{})
+		switch stringValue(delta["type"]) {
+		case "text_delta":
+			text := stringValue(delta["text"])
+			if text == "" {
+				return nil
+			}
+			return t.emitChunk(map[string]interface{}{"content": text}, nil, nil)
+		case "input_json_delta":
+			state, ok := t.toolBlocks[index]
+			if !ok {
+				return nil
+			}
+			return t.emitChunk(map[string]interface{}{
+				"tool_calls": []map[string]interface{}{{
+					"index": state.ToolIndex,
+					"function": map[string]interface{}{
+						"arguments": stringValue(delta["partial_json"]),
+					},
+				}},
+			}, nil, nil)
+		}
+	case "message_delta":
+		delta, _ := payload["delta"].(map[string]interface{})
+		stop := mapAnthropicStopReasonToOpenAI(stringValue(delta["stop_reason"]))
+		if usage, ok := payload["usage"].(map[string]interface{}); ok {
+			t.outputTokens = intValue(usage["output_tokens"])
+		}
+		if err := t.emitChunk(map[string]interface{}{}, &stop, nil); err != nil {
+			return err
+		}
+		return t.emitUsageChunk()
+	case "message_stop":
+		if t.done {
+			return nil
+		}
+		t.done = true
+		_, err := io.WriteString(t.w, "data: [DONE]\n\n")
+		if err == nil {
+			t.flusher.Flush()
+		}
+		return err
+	}
+	return nil
+}
+
+type responsesStreamToolItem struct {
+	ItemID      string
+	OutputIndex int
+	CallID      string
+	Name        string
+	Arguments   strings.Builder
+	Done        bool
+}
+
+type openAIResponsesStreamTranscoder struct {
+	w               http.ResponseWriter
+	flusher         http.Flusher
+	responseID      string
+	model           string
+	created         int64
+	inputTokens     int
+	outputTokens    int
+	createdSent     bool
+	completedSent   bool
+	nextOutputIndex int
+	messageStarted  bool
+	messageItemID   string
+	messageIndex    int
+	messageText     strings.Builder
+	toolBlocks      map[int]*responsesStreamToolItem
+	toolItems       []*responsesStreamToolItem
+}
+
+func newOpenAIResponsesStreamTranscoder(w http.ResponseWriter, flusher http.Flusher, responseID, model string, created int64) *openAIResponsesStreamTranscoder {
+	return &openAIResponsesStreamTranscoder{
+		w:          w,
+		flusher:    flusher,
+		responseID: responseID,
+		model:      model,
+		created:    created,
+		toolBlocks: make(map[int]*responsesStreamToolItem),
+	}
+}
+
+func (t *openAIResponsesStreamTranscoder) emit(eventType string, payload map[string]interface{}) error {
+	payload["type"] = eventType
+	return sendOpenAISSEEvent(t.w, t.flusher, eventType, payload)
+}
+
+func (t *openAIResponsesStreamTranscoder) ensureCreated() error {
+	if t.createdSent {
+		return nil
+	}
+	t.createdSent = true
+	return t.emit("response.created", map[string]interface{}{
+		"response": map[string]interface{}{
+			"id":         t.responseID,
+			"object":     "response",
+			"created_at": t.created,
+			"status":     "in_progress",
+			"model":      t.model,
+			"output":     []interface{}{},
+		},
+	})
+}
+
+func (t *openAIResponsesStreamTranscoder) ensureMessageItem() error {
+	if t.messageStarted {
+		return nil
+	}
+	if err := t.ensureCreated(); err != nil {
+		return err
+	}
+	t.messageStarted = true
+	t.messageIndex = t.nextOutputIndex
+	t.nextOutputIndex++
+	t.messageItemID = "msg_" + compactUUID()
+	return t.emit("response.output_item.added", map[string]interface{}{
+		"response_id":  t.responseID,
+		"output_index": t.messageIndex,
+		"item": map[string]interface{}{
+			"id":     t.messageItemID,
+			"type":   "message",
+			"status": "in_progress",
+			"role":   "assistant",
+			"content": []map[string]interface{}{{
+				"type":        "output_text",
+				"text":        "",
+				"annotations": []interface{}{},
+			}},
+		},
+	})
+}
+
+func (t *openAIResponsesStreamTranscoder) buildFinalResponseObject() map[string]interface{} {
+	output := make([]map[string]interface{}, 0, 1+len(t.toolItems))
+	if t.messageStarted {
+		output = append(output, map[string]interface{}{
+			"id":     t.messageItemID,
+			"type":   "message",
+			"status": "completed",
+			"role":   "assistant",
+			"content": []map[string]interface{}{{
+				"type":        "output_text",
+				"text":        t.messageText.String(),
+				"annotations": []interface{}{},
+			}},
+		})
+	}
+	for _, item := range t.toolItems {
+		output = append(output, map[string]interface{}{
+			"id":        item.ItemID,
+			"type":      "function_call",
+			"status":    "completed",
+			"call_id":   item.CallID,
+			"name":      item.Name,
+			"arguments": item.Arguments.String(),
+		})
+	}
+	return map[string]interface{}{
+		"id":         t.responseID,
+		"object":     "response",
+		"created_at": t.created,
+		"status":     "completed",
+		"model":      t.model,
+		"output":     output,
+		"usage": map[string]int{
+			"input_tokens":  t.inputTokens,
+			"output_tokens": t.outputTokens,
+			"total_tokens":  t.inputTokens + t.outputTokens,
+		},
+	}
+}
+
+func (t *openAIResponsesStreamTranscoder) finalizeMessageItem() error {
+	if !t.messageStarted {
+		return nil
+	}
+	if err := t.emit("response.output_text.done", map[string]interface{}{
+		"response_id":   t.responseID,
+		"output_index":  t.messageIndex,
+		"content_index": 0,
+		"text":          t.messageText.String(),
+	}); err != nil {
+		return err
+	}
+	return t.emit("response.output_item.done", map[string]interface{}{
+		"response_id":  t.responseID,
+		"output_index": t.messageIndex,
+		"item": map[string]interface{}{
+			"id":     t.messageItemID,
+			"type":   "message",
+			"status": "completed",
+			"role":   "assistant",
+			"content": []map[string]interface{}{{
+				"type":        "output_text",
+				"text":        t.messageText.String(),
+				"annotations": []interface{}{},
+			}},
+		},
+	})
+}
+
+func (t *openAIResponsesStreamTranscoder) finalizeToolItem(index int) error {
+	item, ok := t.toolBlocks[index]
+	if !ok || item.Done {
+		return nil
+	}
+	item.Done = true
+	if err := t.emit("response.function_call_arguments.done", map[string]interface{}{
+		"response_id":  t.responseID,
+		"output_index": item.OutputIndex,
+		"item_id":      item.ItemID,
+		"arguments":    item.Arguments.String(),
+	}); err != nil {
+		return err
+	}
+	return t.emit("response.output_item.done", map[string]interface{}{
+		"response_id":  t.responseID,
+		"output_index": item.OutputIndex,
+		"item": map[string]interface{}{
+			"id":        item.ItemID,
+			"type":      "function_call",
+			"status":    "completed",
+			"call_id":   item.CallID,
+			"name":      item.Name,
+			"arguments": item.Arguments.String(),
+		},
+	})
+}
+
+func (t *openAIResponsesStreamTranscoder) HandleFrame(frame anthropicSSEFrame) error {
+	var payload map[string]interface{}
+	if len(frame.Data) > 0 {
+		if err := json.Unmarshal(frame.Data, &payload); err != nil {
+			return err
+		}
+	}
+
+	switch frame.Event {
+	case "message_start":
+		if message, ok := payload["message"].(map[string]interface{}); ok {
+			if usage, ok := message["usage"].(map[string]interface{}); ok {
+				t.inputTokens = intValue(usage["input_tokens"])
+			}
+		}
+		return t.ensureCreated()
+	case "content_block_start":
+		if err := t.ensureCreated(); err != nil {
+			return err
+		}
+		index := intValue(payload["index"])
+		block, _ := payload["content_block"].(map[string]interface{})
+		if stringValue(block["type"]) == "tool_use" {
+			item := &responsesStreamToolItem{
+				ItemID:      "fc_" + compactUUID(),
+				OutputIndex: t.nextOutputIndex,
+				CallID:      stringValue(block["id"]),
+				Name:        stringValue(block["name"]),
+			}
+			t.nextOutputIndex++
+			t.toolBlocks[index] = item
+			t.toolItems = append(t.toolItems, item)
+			return t.emit("response.output_item.added", map[string]interface{}{
+				"response_id":  t.responseID,
+				"output_index": item.OutputIndex,
+				"item": map[string]interface{}{
+					"id":        item.ItemID,
+					"type":      "function_call",
+					"status":    "in_progress",
+					"call_id":   item.CallID,
+					"name":      item.Name,
+					"arguments": "",
+				},
+			})
+		}
+	case "content_block_delta":
+		delta, _ := payload["delta"].(map[string]interface{})
+		switch stringValue(delta["type"]) {
+		case "text_delta":
+			text := stringValue(delta["text"])
+			if text == "" {
+				return nil
+			}
+			if err := t.ensureMessageItem(); err != nil {
+				return err
+			}
+			t.messageText.WriteString(text)
+			return t.emit("response.output_text.delta", map[string]interface{}{
+				"response_id":   t.responseID,
+				"output_index":  t.messageIndex,
+				"content_index": 0,
+				"delta":         text,
+			})
+		case "input_json_delta":
+			index := intValue(payload["index"])
+			item, ok := t.toolBlocks[index]
+			if !ok {
+				return nil
+			}
+			chunk := stringValue(delta["partial_json"])
+			item.Arguments.WriteString(chunk)
+			return t.emit("response.function_call_arguments.delta", map[string]interface{}{
+				"response_id":  t.responseID,
+				"output_index": item.OutputIndex,
+				"item_id":      item.ItemID,
+				"delta":        chunk,
+			})
+		}
+	case "content_block_stop":
+		return t.finalizeToolItem(intValue(payload["index"]))
+	case "message_delta":
+		if usage, ok := payload["usage"].(map[string]interface{}); ok {
+			t.outputTokens = intValue(usage["output_tokens"])
+		}
+		if err := t.finalizeMessageItem(); err != nil {
+			return err
+		}
+		if t.completedSent {
+			return nil
+		}
+		t.completedSent = true
+		return t.emit("response.completed", map[string]interface{}{
+			"response": t.buildFinalResponseObject(),
+		})
+	case "message_stop":
+		return nil
+	}
+	return nil
+}
+
+func HandleOpenAIChatCompletions(pool *AccountPool) http.HandlerFunc {
+	anthropicHandler := HandleAnthropicMessages(pool)
+	return func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			writeOpenAIError(w, http.StatusMethodNotAllowed, "method not allowed", "invalid_request_error", "")
+			return
+		}
+
+		bodyBytes, err := io.ReadAll(r.Body)
+		if err != nil {
+			writeOpenAIError(w, http.StatusBadRequest, "failed to read request body: "+err.Error(), "invalid_request_error", "")
+			return
+		}
+		if len(bodyBytes) == 0 {
+			writeOpenAIError(w, http.StatusBadRequest, "request body is required", "invalid_request_error", "")
+			return
+		}
+		LogAPIInputJSONBytes("openai-chat", "incoming /v1/chat/completions request", bodyBytes)
+
+		var req OpenAIChatCompletionRequest
+		if err := json.Unmarshal(bodyBytes, &req); err != nil {
+			writeOpenAIError(w, http.StatusBadRequest, "invalid request body: "+err.Error(), "invalid_request_error", "")
+			return
+		}
+		anthReq, err := convertOpenAIChatCompletionRequest(&req)
+		if err != nil {
+			writeOpenAIError(w, http.StatusBadRequest, err.Error(), "invalid_request_error", "")
+			return
+		}
+
+		respID := "chatcmpl_" + compactUUID()
+		created := time.Now().Unix()
+		if req.Stream {
+			streamAnthropicAsOpenAIChat(w, r, anthropicHandler, anthReq, respID, created, req.StreamOptions != nil && req.StreamOptions.IncludeUsage)
+			return
+		}
+
+		anthResp, invErr := invokeAnthropicNonStream(anthropicHandler, r, anthReq)
+		if invErr != nil {
+			writeOpenAIError(w, invErr.Status, invErr.Message, invErr.Type, "")
+			return
+		}
+
+		resp := buildOpenAIChatCompletionResponse(respID, created, anthReq.Model, anthResp)
+		LogAPIOutputJSON(respID, "openai chat completions response", resp)
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(resp)
+	}
+}
+
+func HandleOpenAIResponses(pool *AccountPool) http.HandlerFunc {
+	anthropicHandler := HandleAnthropicMessages(pool)
+	return func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			writeOpenAIError(w, http.StatusMethodNotAllowed, "method not allowed", "invalid_request_error", "")
+			return
+		}
+
+		bodyBytes, err := io.ReadAll(r.Body)
+		if err != nil {
+			writeOpenAIError(w, http.StatusBadRequest, "failed to read request body: "+err.Error(), "invalid_request_error", "")
+			return
+		}
+		if len(bodyBytes) == 0 {
+			writeOpenAIError(w, http.StatusBadRequest, "request body is required", "invalid_request_error", "")
+			return
+		}
+		LogAPIInputJSONBytes("openai-resp", "incoming /v1/responses request", bodyBytes)
+
+		var req OpenAIResponsesRequest
+		if err := json.Unmarshal(bodyBytes, &req); err != nil {
+			writeOpenAIError(w, http.StatusBadRequest, "invalid request body: "+err.Error(), "invalid_request_error", "")
+			return
+		}
+		anthReq, err := convertOpenAIResponsesRequest(&req)
+		if err != nil {
+			writeOpenAIError(w, http.StatusBadRequest, err.Error(), "invalid_request_error", "")
+			return
+		}
+
+		respID := "resp_" + compactUUID()
+		created := time.Now().Unix()
+		if req.Stream {
+			streamAnthropicAsOpenAIResponses(w, r, anthropicHandler, anthReq, respID, created)
+			return
+		}
+
+		anthResp, invErr := invokeAnthropicNonStream(anthropicHandler, r, anthReq)
+		if invErr != nil {
+			writeOpenAIError(w, invErr.Status, invErr.Message, invErr.Type, "")
+			return
+		}
+
+		resp := buildOpenAIResponsesResponse(respID, created, anthReq.Model, anthResp)
+		LogAPIOutputJSON(respID, "openai responses response", resp)
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(resp)
+	}
+}
+
+func streamAnthropicAsOpenAIChat(w http.ResponseWriter, r *http.Request, anthropicHandler http.HandlerFunc, anthropicReq *AnthropicRequest, responseID string, created int64, includeUsage bool) {
+	bridge := newAnthropicStreamBridgeWriter()
+	innerReq, err := newAnthropicBridgeRequest(r, anthropicReq)
+	if err != nil {
+		writeOpenAIError(w, http.StatusInternalServerError, err.Error(), "api_error", "")
+		return
+	}
+	go func() {
+		anthropicHandler(bridge, innerReq)
+		bridge.Close()
+	}()
+
+	flusher, ok := w.(http.Flusher)
+	if !ok {
+		writeOpenAIError(w, http.StatusInternalServerError, "streaming not supported", "api_error", "")
+		return
+	}
+	transcoder := newOpenAIChatStreamTranscoder(w, flusher, responseID, anthropicReq.Model, created, includeUsage)
+	headersSent := false
+	for raw := range bridge.frames {
+		if bridge.Status() != http.StatusOK {
+			continue
+		}
+		frame, err := parseAnthropicSSEFrame(raw)
+		if err != nil {
+			writeOpenAIError(w, http.StatusBadGateway, "failed to parse Anthropic stream: "+err.Error(), "api_error", "")
+			return
+		}
+		if !headersSent {
+			w.Header().Set("Content-Type", "text/event-stream")
+			w.Header().Set("Cache-Control", "no-cache")
+			w.Header().Set("Connection", "keep-alive")
+			w.Header().Set("X-Accel-Buffering", "no")
+			headersSent = true
+		}
+		if err := transcoder.HandleFrame(frame); err != nil {
+			writeOpenAIError(w, http.StatusBadGateway, "failed to map Anthropic stream: "+err.Error(), "api_error", "")
+			return
+		}
+	}
+
+	if bridge.Status() != http.StatusOK {
+		invErr := parseAnthropicInvocationError(bridge.Status(), bridge.ErrorBody())
+		writeOpenAIError(w, invErr.Status, invErr.Message, invErr.Type, "")
+	}
+}
+
+func streamAnthropicAsOpenAIResponses(w http.ResponseWriter, r *http.Request, anthropicHandler http.HandlerFunc, anthropicReq *AnthropicRequest, responseID string, created int64) {
+	bridge := newAnthropicStreamBridgeWriter()
+	innerReq, err := newAnthropicBridgeRequest(r, anthropicReq)
+	if err != nil {
+		writeOpenAIError(w, http.StatusInternalServerError, err.Error(), "api_error", "")
+		return
+	}
+	go func() {
+		anthropicHandler(bridge, innerReq)
+		bridge.Close()
+	}()
+
+	flusher, ok := w.(http.Flusher)
+	if !ok {
+		writeOpenAIError(w, http.StatusInternalServerError, "streaming not supported", "api_error", "")
+		return
+	}
+	transcoder := newOpenAIResponsesStreamTranscoder(w, flusher, responseID, anthropicReq.Model, created)
+	headersSent := false
+	for raw := range bridge.frames {
+		if bridge.Status() != http.StatusOK {
+			continue
+		}
+		frame, err := parseAnthropicSSEFrame(raw)
+		if err != nil {
+			writeOpenAIError(w, http.StatusBadGateway, "failed to parse Anthropic stream: "+err.Error(), "api_error", "")
+			return
+		}
+		if !headersSent {
+			w.Header().Set("Content-Type", "text/event-stream")
+			w.Header().Set("Cache-Control", "no-cache")
+			w.Header().Set("Connection", "keep-alive")
+			w.Header().Set("X-Accel-Buffering", "no")
+			headersSent = true
+		}
+		if err := transcoder.HandleFrame(frame); err != nil {
+			writeOpenAIError(w, http.StatusBadGateway, "failed to map Anthropic stream: "+err.Error(), "api_error", "")
+			return
+		}
+	}
+
+	if bridge.Status() != http.StatusOK {
+		invErr := parseAnthropicInvocationError(bridge.Status(), bridge.ErrorBody())
+		writeOpenAIError(w, invErr.Status, invErr.Message, invErr.Type, "")
+	}
+}
+
+func invokeAnthropicNonStream(anthropicHandler http.HandlerFunc, sourceReq *http.Request, anthropicReq *AnthropicRequest) (*AnthropicResponse, *anthropicInvocationError) {
+	innerReq, err := newAnthropicBridgeRequest(sourceReq, anthropicReq)
+	if err != nil {
+		return nil, &anthropicInvocationError{Status: http.StatusInternalServerError, Message: err.Error(), Type: "api_error"}
+	}
+	rr := httptest.NewRecorder()
+	anthropicHandler(rr, innerReq)
+	if rr.Code != http.StatusOK {
+		invErr := parseAnthropicInvocationError(rr.Code, rr.Body.Bytes())
+		return nil, &invErr
+	}
+	var anthResp AnthropicResponse
+	if err := json.Unmarshal(rr.Body.Bytes(), &anthResp); err != nil {
+		return nil, &anthropicInvocationError{Status: http.StatusBadGateway, Message: "invalid anthropic response: " + err.Error(), Type: "api_error"}
+	}
+	return &anthResp, nil
+}
+
+func newAnthropicBridgeRequest(sourceReq *http.Request, anthropicReq *AnthropicRequest) (*http.Request, error) {
+	body, err := json.Marshal(anthropicReq)
+	if err != nil {
+		return nil, err
+	}
+	innerReq, err := http.NewRequestWithContext(sourceReq.Context(), http.MethodPost, "/v1/messages", bytes.NewReader(body))
+	if err != nil {
+		return nil, err
+	}
+	innerReq.Header.Set("Content-Type", "application/json")
+	copySelectedHeaders(sourceReq.Header, innerReq.Header, "X-Web-Search", "X-Workspace-Search")
+	return innerReq, nil
+}
+
+func copySelectedHeaders(src, dst http.Header, names ...string) {
+	for _, name := range names {
+		for _, value := range src.Values(name) {
+			dst.Add(name, value)
+		}
+	}
+}
+
+func parseAnthropicInvocationError(status int, body []byte) anthropicInvocationError {
+	invErr := anthropicInvocationError{Status: status, Message: strings.TrimSpace(string(body)), Type: "api_error"}
+	var payload struct {
+		Error struct {
+			Type    string `json:"type"`
+			Message string `json:"message"`
+		} `json:"error"`
+	}
+	if json.Unmarshal(body, &payload) == nil && payload.Error.Message != "" {
+		invErr.Message = payload.Error.Message
+		if payload.Error.Type != "" {
+			invErr.Type = payload.Error.Type
+		}
+	}
+	return invErr
+}
+
+func parseAnthropicSSEFrame(raw string) (anthropicSSEFrame, error) {
+	var frame anthropicSSEFrame
+	lines := strings.Split(raw, "\n")
+	var dataLines []string
+	for _, line := range lines {
+		switch {
+		case strings.HasPrefix(line, "event: "):
+			frame.Event = strings.TrimSpace(strings.TrimPrefix(line, "event: "))
+		case strings.HasPrefix(line, "data: "):
+			dataLines = append(dataLines, strings.TrimPrefix(line, "data: "))
+		}
+	}
+	if frame.Event == "" {
+		return frame, fmt.Errorf("missing event in frame %q", raw)
+	}
+	if len(dataLines) > 0 {
+		frame.Data = json.RawMessage(strings.Join(dataLines, "\n"))
+	}
+	return frame, nil
+}
+
+func sendOpenAISSE(w http.ResponseWriter, flusher http.Flusher, payload interface{}) error {
+	raw, err := json.Marshal(payload)
+	if err != nil {
+		return err
+	}
+	if _, err := fmt.Fprintf(w, "data: %s\n\n", raw); err != nil {
+		return err
+	}
+	flusher.Flush()
+	return nil
+}
+
+func sendOpenAISSEEvent(w http.ResponseWriter, flusher http.Flusher, eventType string, payload interface{}) error {
+	raw, err := json.Marshal(payload)
+	if err != nil {
+		return err
+	}
+	if _, err := fmt.Fprintf(w, "event: %s\ndata: %s\n\n", eventType, raw); err != nil {
+		return err
+	}
+	flusher.Flush()
+	return nil
+}
+
+func buildOpenAIChatCompletionResponse(responseID string, created int64, model string, anthResp *AnthropicResponse) OpenAIChatCompletionResponse {
+	text, toolCalls := extractAnthropicTextAndToolCalls(anthResp.Content)
+	finishReason := mapAnthropicStopReasonToOpenAI(stringValueOrDefault(anthResp.StopReason, "end_turn"))
+	message := map[string]interface{}{
+		"role": "assistant",
+	}
+	if len(toolCalls) > 0 {
+		message["tool_calls"] = toolCalls
+	}
+	if text == "" && len(toolCalls) > 0 {
+		message["content"] = nil
+	} else {
+		message["content"] = text
+	}
+	resp := OpenAIChatCompletionResponse{
+		ID:      responseID,
+		Object:  "chat.completion",
+		Created: created,
+		Model:   model,
+		Choices: []OpenAIChatCompletionChoice{{
+			Index:        0,
+			Message:      message,
+			FinishReason: &finishReason,
+		}},
+	}
+	if anthResp.Usage != nil {
+		resp.Usage = map[string]int{
+			"prompt_tokens":     anthResp.Usage.InputTokens,
+			"completion_tokens": anthResp.Usage.OutputTokens,
+			"total_tokens":      anthResp.Usage.InputTokens + anthResp.Usage.OutputTokens,
+		}
+	}
+	return resp
+}
+
+func buildOpenAIResponsesResponse(responseID string, created int64, model string, anthResp *AnthropicResponse) map[string]interface{} {
+	text, toolCalls := extractAnthropicTextAndToolCalls(anthResp.Content)
+	output := make([]map[string]interface{}, 0, 1+len(toolCalls))
+	if text != "" || len(toolCalls) == 0 {
+		output = append(output, map[string]interface{}{
+			"id":     "msg_" + compactUUID(),
+			"type":   "message",
+			"status": "completed",
+			"role":   "assistant",
+			"content": []map[string]interface{}{{
+				"type":        "output_text",
+				"text":        text,
+				"annotations": []interface{}{},
+			}},
+		})
+	}
+	for _, toolCall := range toolCalls {
+		output = append(output, map[string]interface{}{
+			"id":        "fc_" + compactUUID(),
+			"type":      "function_call",
+			"status":    "completed",
+			"call_id":   toolCall.ID,
+			"name":      toolCall.Function.Name,
+			"arguments": toolCall.Function.Arguments,
+		})
+	}
+	resp := map[string]interface{}{
+		"id":         responseID,
+		"object":     "response",
+		"created_at": created,
+		"status":     "completed",
+		"model":      model,
+		"output":     output,
+	}
+	if anthResp.Usage != nil {
+		resp["usage"] = map[string]int{
+			"input_tokens":  anthResp.Usage.InputTokens,
+			"output_tokens": anthResp.Usage.OutputTokens,
+			"total_tokens":  anthResp.Usage.InputTokens + anthResp.Usage.OutputTokens,
+		}
+	}
+	return resp
+}
+
+func extractAnthropicTextAndToolCalls(blocks []AnthropicContentBlock) (string, []OpenAIChatToolCall) {
+	var text strings.Builder
+	var toolCalls []OpenAIChatToolCall
+	for _, block := range blocks {
+		switch block.Type {
+		case "text":
+			text.WriteString(block.Text)
+		case "tool_use":
+			toolCalls = append(toolCalls, OpenAIChatToolCall{
+				ID:   block.ID,
+				Type: "function",
+				Function: OpenAIChatToolCallFunction{
+					Name:      block.Name,
+					Arguments: string(block.Input),
+				},
+			})
+		}
+	}
+	return text.String(), toolCalls
+}
+
+func convertOpenAIChatCompletionRequest(req *OpenAIChatCompletionRequest) (*AnthropicRequest, error) {
+	if req.N > 1 {
+		return nil, fmt.Errorf("n > 1 is not supported")
+	}
+	if len(req.Messages) == 0 {
+		return nil, fmt.Errorf("messages is required")
+	}
+	model := strings.TrimSpace(req.Model)
+	if model == "" {
+		model = AppConfig.Proxy.DefaultModel
+	}
+	tools, err := convertOpenAITools(req.Tools, req.Functions)
+	if err != nil {
+		return nil, err
+	}
+	system, messages, err := convertOpenAIChatMessagesToAnthropic(req.Messages)
+	if err != nil {
+		return nil, err
+	}
+	anthReq := &AnthropicRequest{
+		Model:        model,
+		MaxTokens:    firstNonZero(req.MaxCompletionTokens, req.MaxTokens),
+		System:       system,
+		Messages:     messages,
+		Stream:       req.Stream,
+		Temperature:  req.Temperature,
+		TopP:         req.TopP,
+		Tools:        tools,
+		ToolChoice:   normalizeOpenAIToolChoice(req.ToolChoice, req.FunctionCall),
+		OutputConfig: convertOpenAIResponseFormat(req.ResponseFormat),
+		Metadata:     req.Metadata,
+	}
+	return anthReq, nil
+}
+
+func convertOpenAIResponsesRequest(req *OpenAIResponsesRequest) (*AnthropicRequest, error) {
+	if strings.TrimSpace(req.PreviousResponseID) != "" {
+		return nil, fmt.Errorf("previous_response_id is not supported in this stateless Responses bridge")
+	}
+	model := strings.TrimSpace(req.Model)
+	if model == "" {
+		model = AppConfig.Proxy.DefaultModel
+	}
+	tools, err := convertOpenAITools(req.Tools, nil)
+	if err != nil {
+		return nil, err
+	}
+	system, messages, err := convertOpenAIResponsesInputToAnthropic(req.Instructions, req.Input)
+	if err != nil {
+		return nil, err
+	}
+	if len(messages) == 0 {
+		return nil, fmt.Errorf("input is required")
+	}
+	return &AnthropicRequest{
+		Model:        model,
+		MaxTokens:    req.MaxOutputTokens,
+		System:       system,
+		Messages:     messages,
+		Stream:       req.Stream,
+		Temperature:  req.Temperature,
+		TopP:         req.TopP,
+		Tools:        tools,
+		ToolChoice:   req.ToolChoice,
+		OutputConfig: convertOpenAIResponsesTextFormat(req.Text),
+		Metadata:     req.Metadata,
+	}, nil
+}
+
+func convertOpenAITools(tools []OpenAITool, functions []OpenAIFunctionDefinition) ([]AnthropicTool, error) {
+	if len(tools) == 0 && len(functions) == 0 {
+		return nil, nil
+	}
+	var anthropicTools []AnthropicTool
+	if len(tools) == 0 {
+		for _, fn := range functions {
+			anthropicTools = append(anthropicTools, AnthropicTool{
+				Name:        fn.Name,
+				Description: fn.Description,
+				InputSchema: ensureJSONSchemaObject(fn.Parameters),
+			})
+		}
+		return anthropicTools, nil
+	}
+	for _, tool := range tools {
+		switch tool.Type {
+		case "function":
+			fn := tool.Function
+			if fn == nil {
+				fn = &OpenAIFunctionDefinition{
+					Name:        tool.Name,
+					Description: tool.Description,
+					Parameters:  tool.Parameters,
+				}
+			}
+			if strings.TrimSpace(fn.Name) == "" {
+				return nil, fmt.Errorf("tool.function.name is required")
+			}
+			anthropicTools = append(anthropicTools, AnthropicTool{
+				Name:        fn.Name,
+				Description: fn.Description,
+				InputSchema: ensureJSONSchemaObject(fn.Parameters),
+			})
+		default:
+			return nil, fmt.Errorf("unsupported tool type %q", tool.Type)
+		}
+	}
+	return anthropicTools, nil
+}
+
+func normalizeOpenAIToolChoice(toolChoice interface{}, functionCall interface{}) interface{} {
+	if toolChoice != nil {
+		return toolChoice
+	}
+	if functionCall == nil {
+		return nil
+	}
+	switch v := functionCall.(type) {
+	case string:
+		return v
+	case map[string]interface{}:
+		if name, ok := v["name"].(string); ok && name != "" {
+			return map[string]interface{}{
+				"type":     "function",
+				"function": map[string]interface{}{"name": name},
+			}
+		}
+	}
+	return functionCall
+}
+
+func convertOpenAIChatMessagesToAnthropic(messages []OpenAIChatMessage) (interface{}, []AnthropicMessage, error) {
+	var systemParts []string
+	var anthropicMsgs []AnthropicMessage
+	for _, msg := range messages {
+		role := strings.TrimSpace(msg.Role)
+		switch role {
+		case "system", "developer":
+			text, err := flattenOpenAIContentText(msg.Content)
+			if err != nil {
+				return nil, nil, err
+			}
+			if text != "" {
+				systemParts = append(systemParts, text)
+			}
+		case "user":
+			content, err := convertOpenAIContentToAnthropicBlocks(msg.Content, false)
+			if err != nil {
+				return nil, nil, err
+			}
+			anthropicMsgs = append(anthropicMsgs, AnthropicMessage{Role: "user", Content: content})
+		case "assistant":
+			content, err := convertOpenAIAssistantMessageToAnthropicContent(msg)
+			if err != nil {
+				return nil, nil, err
+			}
+			anthropicMsgs = append(anthropicMsgs, AnthropicMessage{Role: "assistant", Content: content})
+		case "tool":
+			content, err := convertOpenAIToolMessageToAnthropicContent(msg.Content, msg.ToolCallID)
+			if err != nil {
+				return nil, nil, err
+			}
+			anthropicMsgs = append(anthropicMsgs, AnthropicMessage{Role: "user", Content: content})
+		default:
+			return nil, nil, fmt.Errorf("unsupported message role %q", role)
+		}
+	}
+	var system interface{}
+	if len(systemParts) > 0 {
+		system = strings.Join(systemParts, "\n\n")
+	}
+	return system, anthropicMsgs, nil
+}
+
+func convertOpenAIResponsesInputToAnthropic(instructions string, input interface{}) (interface{}, []AnthropicMessage, error) {
+	var systemParts []string
+	if trimmed := strings.TrimSpace(instructions); trimmed != "" {
+		systemParts = append(systemParts, trimmed)
+	}
+	var anthropicMsgs []AnthropicMessage
+	flushPendingUser := func(parts []interface{}) {
+		if len(parts) > 0 {
+			anthropicMsgs = append(anthropicMsgs, AnthropicMessage{Role: "user", Content: parts})
+		}
+	}
+
+	switch v := input.(type) {
+	case string:
+		anthropicMsgs = append(anthropicMsgs, AnthropicMessage{Role: "user", Content: v})
+	case map[string]interface{}:
+		return convertOpenAIResponsesInputToAnthropic(instructions, []interface{}{v})
+	case []interface{}:
+		var pendingUserParts []interface{}
+		for _, raw := range v {
+			item, ok := raw.(map[string]interface{})
+			if !ok {
+				return nil, nil, fmt.Errorf("unsupported responses input item %T", raw)
+			}
+			role := stringValue(item["role"])
+			itemType := stringValue(item["type"])
+			switch {
+			case role != "":
+				flushPendingUser(pendingUserParts)
+				pendingUserParts = nil
+				msg, err := convertGenericOpenAIMessageToAnthropic(role, item)
+				if err != nil {
+					return nil, nil, err
+				}
+				if role == "system" || role == "developer" {
+					if text := stringValue(msg.Content); text != "" {
+						systemParts = append(systemParts, text)
+					}
+					continue
+				}
+				anthropicMsgs = append(anthropicMsgs, msg)
+			case itemType == "message":
+				flushPendingUser(pendingUserParts)
+				pendingUserParts = nil
+				msg, err := convertGenericOpenAIMessageToAnthropic(stringValue(item["role"]), item)
+				if err != nil {
+					return nil, nil, err
+				}
+				anthropicMsgs = append(anthropicMsgs, msg)
+			case itemType == "function_call_output":
+				flushPendingUser(pendingUserParts)
+				pendingUserParts = nil
+				content, err := convertOpenAIToolOutputToAnthropicContent(item)
+				if err != nil {
+					return nil, nil, err
+				}
+				anthropicMsgs = append(anthropicMsgs, AnthropicMessage{Role: "user", Content: content})
+			case isOpenAIInputContentType(itemType):
+				blocks, err := convertOpenAIContentItemsToAnthropicBlocks([]interface{}{item}, true)
+				if err != nil {
+					return nil, nil, err
+				}
+				pendingUserParts = append(pendingUserParts, blocks...)
+			default:
+				return nil, nil, fmt.Errorf("unsupported responses input item type %q", itemType)
+			}
+		}
+		flushPendingUser(pendingUserParts)
+	default:
+		return nil, nil, fmt.Errorf("unsupported input type %T", input)
+	}
+
+	var system interface{}
+	if len(systemParts) > 0 {
+		system = strings.Join(systemParts, "\n\n")
+	}
+	return system, anthropicMsgs, nil
+}
+
+func convertGenericOpenAIMessageToAnthropic(role string, item map[string]interface{}) (AnthropicMessage, error) {
+	msg := OpenAIChatMessage{
+		Role:       role,
+		Content:    item["content"],
+		ToolCallID: stringValue(item["tool_call_id"]),
+	}
+	if rawToolCalls, ok := item["tool_calls"].([]interface{}); ok {
+		for _, raw := range rawToolCalls {
+			callMap, ok := raw.(map[string]interface{})
+			if !ok {
+				continue
+			}
+			msg.ToolCalls = append(msg.ToolCalls, OpenAIChatToolCall{
+				ID:   stringValue(callMap["id"]),
+				Type: stringValue(callMap["type"]),
+				Function: OpenAIChatToolCallFunction{
+					Name:      stringValue(nestedMapValue(callMap, "function", "name")),
+					Arguments: stringValue(nestedMapValue(callMap, "function", "arguments")),
+				},
+			})
+		}
+	}
+	switch role {
+	case "system", "developer":
+		text, err := flattenOpenAIContentText(msg.Content)
+		if err != nil {
+			return AnthropicMessage{}, err
+		}
+		return AnthropicMessage{Role: role, Content: text}, nil
+	case "user":
+		content, err := convertOpenAIContentToAnthropicBlocks(msg.Content, false)
+		if err != nil {
+			return AnthropicMessage{}, err
+		}
+		return AnthropicMessage{Role: "user", Content: content}, nil
+	case "assistant":
+		content, err := convertOpenAIAssistantMessageToAnthropicContent(msg)
+		if err != nil {
+			return AnthropicMessage{}, err
+		}
+		return AnthropicMessage{Role: "assistant", Content: content}, nil
+	case "tool":
+		content, err := convertOpenAIToolMessageToAnthropicContent(msg.Content, msg.ToolCallID)
+		if err != nil {
+			return AnthropicMessage{}, err
+		}
+		return AnthropicMessage{Role: "user", Content: content}, nil
+	default:
+		return AnthropicMessage{}, fmt.Errorf("unsupported role %q", role)
+	}
+}
+
+func convertOpenAIAssistantMessageToAnthropicContent(msg OpenAIChatMessage) (interface{}, error) {
+	var blocks []interface{}
+	textBlocks, err := convertOpenAIContentToAnthropicBlocks(msg.Content, true)
+	if err != nil {
+		return nil, err
+	}
+	blocks = append(blocks, textBlocks...)
+	for _, call := range msg.ToolCalls {
+		args := strings.TrimSpace(call.Function.Arguments)
+		if args == "" {
+			args = "{}"
+		}
+		if !json.Valid([]byte(args)) {
+			return nil, fmt.Errorf("assistant tool call %s has invalid JSON arguments", call.Function.Name)
+		}
+		blocks = append(blocks, map[string]interface{}{
+			"type":  "tool_use",
+			"id":    defaultString(call.ID, "call_"+compactUUID()),
+			"name":  call.Function.Name,
+			"input": json.RawMessage(args),
+		})
+	}
+	if len(blocks) == 0 {
+		return "", nil
+	}
+	return blocks, nil
+}
+
+func convertOpenAIToolMessageToAnthropicContent(content interface{}, toolCallID string) (interface{}, error) {
+	if strings.TrimSpace(toolCallID) == "" {
+		return nil, fmt.Errorf("tool_call_id is required for tool messages")
+	}
+	toolContent, err := convertOpenAIToolResultContent(content)
+	if err != nil {
+		return nil, err
+	}
+	return []interface{}{map[string]interface{}{
+		"type":        "tool_result",
+		"tool_use_id": toolCallID,
+		"content":     toolContent,
+	}}, nil
+}
+
+func convertOpenAIToolOutputToAnthropicContent(item map[string]interface{}) (interface{}, error) {
+	callID := stringValue(item["call_id"])
+	if callID == "" {
+		callID = stringValue(item["tool_call_id"])
+	}
+	if callID == "" {
+		return nil, fmt.Errorf("function_call_output.call_id is required")
+	}
+	toolContent, err := convertOpenAIToolResultContent(item["output"])
+	if err != nil {
+		return nil, err
+	}
+	return []interface{}{map[string]interface{}{
+		"type":        "tool_result",
+		"tool_use_id": callID,
+		"content":     toolContent,
+	}}, nil
+}
+
+func convertOpenAIToolResultContent(content interface{}) (interface{}, error) {
+	switch v := content.(type) {
+	case nil:
+		return "", nil
+	case string:
+		return v, nil
+	case []interface{}:
+		var parts []map[string]interface{}
+		for _, raw := range v {
+			item, ok := raw.(map[string]interface{})
+			if !ok {
+				continue
+			}
+			text := stringValue(item["text"])
+			if text == "" {
+				text = stringValue(item["content"])
+			}
+			if text == "" {
+				continue
+			}
+			parts = append(parts, map[string]interface{}{"type": "text", "text": text})
+		}
+		if len(parts) == 0 {
+			return "", nil
+		}
+		result := make([]interface{}, 0, len(parts))
+		for _, part := range parts {
+			result = append(result, part)
+		}
+		return result, nil
+	default:
+		raw, err := json.Marshal(v)
+		if err != nil {
+			return nil, err
+		}
+		return string(raw), nil
+	}
+}
+
+func convertOpenAIContentToAnthropicBlocks(content interface{}, allowEmpty bool) ([]interface{}, error) {
+	switch v := content.(type) {
+	case nil:
+		if allowEmpty {
+			return nil, nil
+		}
+		return []interface{}{}, nil
+	case string:
+		if v == "" {
+			return nil, nil
+		}
+		return []interface{}{map[string]interface{}{"type": "text", "text": v}}, nil
+	case []interface{}:
+		return convertOpenAIContentItemsToAnthropicBlocks(v, allowEmpty)
+	default:
+		raw, err := json.Marshal(v)
+		if err != nil {
+			return nil, err
+		}
+		return []interface{}{map[string]interface{}{"type": "text", "text": string(raw)}}, nil
+	}
+}
+
+func convertOpenAIContentItemsToAnthropicBlocks(items []interface{}, allowEmpty bool) ([]interface{}, error) {
+	var blocks []interface{}
+	for _, raw := range items {
+		item, ok := raw.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		typeName := stringValue(item["type"])
+		switch typeName {
+		case "text", "input_text", "output_text":
+			text := stringValue(item["text"])
+			if text == "" {
+				text = stringValue(item["content"])
+			}
+			if text != "" {
+				blocks = append(blocks, map[string]interface{}{"type": "text", "text": text})
+			}
+		case "image_url":
+			source, err := convertOpenAIImageSource(item["image_url"])
+			if err != nil {
+				return nil, err
+			}
+			blocks = append(blocks, map[string]interface{}{"type": "image", "source": source})
+		case "input_image":
+			imagePayload := item["image_url"]
+			if imagePayload == nil {
+				imagePayload = item["url"]
+			}
+			if imagePayload == nil {
+				imagePayload = item["image"]
+			}
+			source, err := convertOpenAIImageSource(imagePayload)
+			if err != nil {
+				return nil, err
+			}
+			blocks = append(blocks, map[string]interface{}{"type": "image", "source": source})
+		case "file", "input_file":
+			source, err := convertOpenAIFileSource(item)
+			if err != nil {
+				return nil, err
+			}
+			blocks = append(blocks, map[string]interface{}{"type": "document", "source": source})
+		default:
+			if typeName == "" && stringValue(item["text"]) != "" {
+				blocks = append(blocks, map[string]interface{}{"type": "text", "text": stringValue(item["text"])})
+				continue
+			}
+			return nil, fmt.Errorf("unsupported content item type %q", typeName)
+		}
+	}
+	if len(blocks) == 0 && !allowEmpty {
+		return []interface{}{}, nil
+	}
+	return blocks, nil
+}
+
+func convertOpenAIImageSource(value interface{}) (map[string]interface{}, error) {
+	switch v := value.(type) {
+	case string:
+		return normalizeOpenAIURLSource(v, "image/png")
+	case map[string]interface{}:
+		if fileID := stringValue(v["file_id"]); fileID != "" {
+			return nil, fmt.Errorf("image file_id %q is not supported without the Files API", fileID)
+		}
+		url := stringValue(v["url"])
+		if url == "" {
+			url = stringValue(v["image_url"])
+		}
+		if url == "" {
+			return nil, fmt.Errorf("image_url.url is required")
+		}
+		return normalizeOpenAIURLSource(url, "image/png")
+	default:
+		return nil, fmt.Errorf("unsupported image payload %T", value)
+	}
+}
+
+func convertOpenAIFileSource(item map[string]interface{}) (map[string]interface{}, error) {
+	payload := item
+	if nested, ok := item["file"].(map[string]interface{}); ok {
+		payload = nested
+	}
+	if fileID := stringValue(payload["file_id"]); fileID != "" {
+		return nil, fmt.Errorf("file_id %q is not supported without the Files API", fileID)
+	}
+	if dataURL := stringValue(payload["url"]); dataURL != "" {
+		return normalizeOpenAIURLSource(dataURL, detectMediaTypeFromPayload(payload, "application/pdf"))
+	}
+	fileData := stringValue(payload["file_data"])
+	if fileData == "" {
+		fileData = stringValue(payload["data"])
+	}
+	if fileData == "" {
+		return nil, fmt.Errorf("file_data or url is required for file inputs")
+	}
+	if parsed, ok := parseDataURL(fileData); ok {
+		return map[string]interface{}{
+			"type":       "base64",
+			"media_type": parsed.MediaType,
+			"data":       parsed.Data,
+		}, nil
+	}
+	mediaType := detectMediaTypeFromPayload(payload, "application/pdf")
+	if _, err := base64.StdEncoding.DecodeString(fileData); err != nil {
+		return nil, fmt.Errorf("file_data must be base64: %w", err)
+	}
+	return map[string]interface{}{
+		"type":       "base64",
+		"media_type": mediaType,
+		"data":       fileData,
+	}, nil
+}
+
+func normalizeOpenAIURLSource(raw string, defaultMediaType string) (map[string]interface{}, error) {
+	if parsed, ok := parseDataURL(raw); ok {
+		return map[string]interface{}{
+			"type":       "base64",
+			"media_type": parsed.MediaType,
+			"data":       parsed.Data,
+		}, nil
+	}
+	if !strings.HasPrefix(raw, "http://") && !strings.HasPrefix(raw, "https://") {
+		return nil, fmt.Errorf("unsupported URL source %q", truncateForLog(raw, 60))
+	}
+	return map[string]interface{}{
+		"type": "url",
+		"url":  raw,
+	}, nil
+}
+
+type parsedDataURL struct {
+	MediaType string
+	Data      string
+}
+
+func parseDataURL(raw string) (parsedDataURL, bool) {
+	if !strings.HasPrefix(raw, "data:") {
+		return parsedDataURL{}, false
+	}
+	comma := strings.Index(raw, ",")
+	if comma <= 5 {
+		return parsedDataURL{}, false
+	}
+	header := raw[5:comma]
+	data := raw[comma+1:]
+	if !strings.Contains(header, ";base64") {
+		return parsedDataURL{}, false
+	}
+	mediaType := strings.TrimSuffix(header, ";base64")
+	if mediaType == "" {
+		mediaType = "application/octet-stream"
+	}
+	return parsedDataURL{MediaType: mediaType, Data: data}, true
+}
+
+func detectMediaTypeFromPayload(payload map[string]interface{}, fallback string) string {
+	for _, key := range []string{"mime_type", "media_type", "content_type"} {
+		if value := stringValue(payload[key]); value != "" {
+			return value
+		}
+	}
+	if filename := stringValue(payload["filename"]); filename != "" {
+		if detected := mime.TypeByExtension(filepath.Ext(filename)); detected != "" {
+			return detected
+		}
+	}
+	return fallback
+}
+
+func flattenOpenAIContentText(content interface{}) (string, error) {
+	switch v := content.(type) {
+	case nil:
+		return "", nil
+	case string:
+		return v, nil
+	case []interface{}:
+		var sb strings.Builder
+		for _, raw := range v {
+			item, ok := raw.(map[string]interface{})
+			if !ok {
+				continue
+			}
+			typeName := stringValue(item["type"])
+			switch typeName {
+			case "text", "input_text", "output_text":
+				sb.WriteString(stringValue(item["text"]))
+			case "image_url", "input_image", "file", "input_file":
+				// 非文本内容留给专门的内容块转换处理；系统消息里忽略。
+			default:
+				if typeName == "" && stringValue(item["text"]) != "" {
+					sb.WriteString(stringValue(item["text"]))
+					continue
+				}
+				return "", fmt.Errorf("unsupported content item type %q in text-only context", typeName)
+			}
+		}
+		return sb.String(), nil
+	default:
+		raw, err := json.Marshal(v)
+		if err != nil {
+			return "", err
+		}
+		return string(raw), nil
+	}
+}
+
+func convertOpenAIResponseFormat(format *OpenAIChatResponseFormat) *AnthropicOutputConfig {
+	if format == nil {
+		return nil
+	}
+	switch format.Type {
+	case "json_schema":
+		if format.JSONSchema == nil || format.JSONSchema.Schema == nil {
+			return nil
+		}
+		return &AnthropicOutputConfig{Format: &AnthropicOutputFormat{Type: "json_schema", Schema: format.JSONSchema.Schema}}
+	case "json_object":
+		return &AnthropicOutputConfig{Format: &AnthropicOutputFormat{Type: "json_schema", Schema: looseJSONObjectSchema()}}
+	default:
+		return nil
+	}
+}
+
+func convertOpenAIResponsesTextFormat(textCfg *OpenAIResponsesTextConfig) *AnthropicOutputConfig {
+	if textCfg == nil {
+		return nil
+	}
+	return convertOpenAIResponseFormat(textCfg.Format)
+}
+
+func looseJSONObjectSchema() interface{} {
+	return map[string]interface{}{
+		"type":                 "object",
+		"additionalProperties": true,
+	}
+}
+
+func ensureJSONSchemaObject(schema interface{}) interface{} {
+	if schema == nil {
+		return map[string]interface{}{"type": "object", "properties": map[string]interface{}{}}
+	}
+	return schema
+}
+
+func writeOpenAIError(w http.ResponseWriter, status int, message, errType, param string) {
+	payload := OpenAIErrorResponse{Error: OpenAIError{Message: message, Type: errType, Param: param}}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	json.NewEncoder(w).Encode(payload)
+}
+
+func mapAnthropicStopReasonToOpenAI(stopReason string) string {
+	switch stopReason {
+	case "tool_use":
+		return "tool_calls"
+	case "max_tokens":
+		return "length"
+	default:
+		return "stop"
+	}
+}
+
+func compactUUID() string {
+	return strings.ReplaceAll(generateUUIDv4(), "-", "")
+}
+
+func intValue(v interface{}) int {
+	switch n := v.(type) {
+	case int:
+		return n
+	case int64:
+		return int(n)
+	case float64:
+		return int(n)
+	case json.Number:
+		if i, err := n.Int64(); err == nil {
+			return int(i)
+		}
+	}
+	return 0
+}
+
+func stringValue(v interface{}) string {
+	switch s := v.(type) {
+	case string:
+		return s
+	case json.RawMessage:
+		return string(s)
+	default:
+		return ""
+	}
+}
+
+func stringValueOrDefault(v *string, fallback string) string {
+	if v == nil || *v == "" {
+		return fallback
+	}
+	return *v
+}
+
+func nestedMapValue(m map[string]interface{}, key string, nested string) interface{} {
+	nv, ok := m[key].(map[string]interface{})
+	if !ok {
+		return nil
+	}
+	return nv[nested]
+}
+
+func defaultString(value string, fallback string) string {
+	if strings.TrimSpace(value) == "" {
+		return fallback
+	}
+	return value
+}
+
+func firstNonZero(values ...int) int {
+	for _, value := range values {
+		if value > 0 {
+			return value
+		}
+	}
+	return 0
+}
+
+func isOpenAIInputContentType(typeName string) bool {
+	switch typeName {
+	case "input_text", "input_image", "input_file", "text", "image_url", "file":
+		return true
+	default:
+		return false
+	}
+}

--- a/internal/proxy/openai_test.go
+++ b/internal/proxy/openai_test.go
@@ -1,0 +1,204 @@
+package proxy
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestConvertOpenAIChatCompletionRequest_WithFilesToolsAndJSONSchema(t *testing.T) {
+	pdfData := base64.StdEncoding.EncodeToString([]byte("%PDF-1.4 mock"))
+	imageData := base64.StdEncoding.EncodeToString([]byte("png-bytes"))
+	req := &OpenAIChatCompletionRequest{
+		Model: "gpt-5.4",
+		Messages: []OpenAIChatMessage{
+			{Role: "developer", Content: "Always answer in Chinese."},
+			{Role: "user", Content: []interface{}{
+				map[string]interface{}{"type": "text", "text": "分析这个文件"},
+				map[string]interface{}{"type": "image_url", "image_url": map[string]interface{}{"url": "data:image/png;base64," + imageData}},
+				map[string]interface{}{"type": "file", "file": map[string]interface{}{"filename": "spec.pdf", "file_data": pdfData}},
+			}},
+		},
+		Tools: []OpenAITool{{
+			Type: "function",
+			Function: &OpenAIFunctionDefinition{
+				Name:        "Read",
+				Description: "Read a file",
+				Parameters: map[string]interface{}{
+					"type": "object",
+					"properties": map[string]interface{}{
+						"path": map[string]interface{}{"type": "string"},
+					},
+				},
+			},
+		}},
+		ToolChoice: map[string]interface{}{
+			"type":     "function",
+			"function": map[string]interface{}{"name": "Read"},
+		},
+		ResponseFormat: &OpenAIChatResponseFormat{
+			Type:       "json_schema",
+			JSONSchema: &OpenAIJSONSchemaConfig{Schema: map[string]interface{}{"type": "object"}},
+		},
+	}
+
+	anthReq, err := convertOpenAIChatCompletionRequest(req)
+	if err != nil {
+		t.Fatalf("convertOpenAIChatCompletionRequest() error = %v", err)
+	}
+	if anthReq.Model != "gpt-5.4" {
+		t.Fatalf("model = %q, want gpt-5.4", anthReq.Model)
+	}
+	if anthReq.System != "Always answer in Chinese." {
+		t.Fatalf("system = %#v", anthReq.System)
+	}
+	if len(anthReq.Tools) != 1 || anthReq.Tools[0].Name != "Read" {
+		t.Fatalf("tools = %#v", anthReq.Tools)
+	}
+	if anthReq.OutputConfig == nil || anthReq.OutputConfig.Format == nil || anthReq.OutputConfig.Format.Type != "json_schema" {
+		t.Fatalf("output_config = %#v", anthReq.OutputConfig)
+	}
+	if len(anthReq.Messages) != 1 {
+		t.Fatalf("messages len = %d, want 1", len(anthReq.Messages))
+	}
+	blocks, ok := anthReq.Messages[0].Content.([]interface{})
+	if !ok || len(blocks) != 3 {
+		t.Fatalf("content blocks = %#v", anthReq.Messages[0].Content)
+	}
+	first := blocks[0].(map[string]interface{})
+	if first["type"] != "text" {
+		t.Fatalf("first block = %#v", first)
+	}
+	second := blocks[1].(map[string]interface{})
+	if second["type"] != "image" {
+		t.Fatalf("second block = %#v", second)
+	}
+	third := blocks[2].(map[string]interface{})
+	if third["type"] != "document" {
+		t.Fatalf("third block = %#v", third)
+	}
+}
+
+func TestConvertOpenAIResponsesRequest_WithFunctionCallOutput(t *testing.T) {
+	req := &OpenAIResponsesRequest{
+		Model:        "gpt-5.4",
+		Instructions: "Return JSON only.",
+		Input: []interface{}{
+			map[string]interface{}{"type": "input_text", "text": "hello"},
+			map[string]interface{}{"type": "function_call_output", "call_id": "call_123", "output": "done"},
+		},
+		Text: &OpenAIResponsesTextConfig{Format: &OpenAIChatResponseFormat{Type: "json_object"}},
+	}
+
+	anthReq, err := convertOpenAIResponsesRequest(req)
+	if err != nil {
+		t.Fatalf("convertOpenAIResponsesRequest() error = %v", err)
+	}
+	if anthReq.System != "Return JSON only." {
+		t.Fatalf("system = %#v", anthReq.System)
+	}
+	if anthReq.OutputConfig == nil || anthReq.OutputConfig.Format == nil || anthReq.OutputConfig.Format.Type != "json_schema" {
+		t.Fatalf("output_config = %#v", anthReq.OutputConfig)
+	}
+	if len(anthReq.Messages) != 2 {
+		t.Fatalf("messages len = %d, want 2", len(anthReq.Messages))
+	}
+	firstBlocks := anthReq.Messages[0].Content.([]interface{})
+	if firstBlocks[0].(map[string]interface{})["type"] != "text" {
+		t.Fatalf("first message blocks = %#v", firstBlocks)
+	}
+	secondBlocks := anthReq.Messages[1].Content.([]interface{})
+	toolResult := secondBlocks[0].(map[string]interface{})
+	if toolResult["type"] != "tool_result" || toolResult["tool_use_id"] != "call_123" {
+		t.Fatalf("tool result = %#v", toolResult)
+	}
+}
+
+func TestBuildOpenAIChatCompletionResponse_FromAnthropicBlocks(t *testing.T) {
+	stopReason := "tool_use"
+	resp := buildOpenAIChatCompletionResponse("chatcmpl_test", 123, "gpt-5.4", &AnthropicResponse{
+		Content: []AnthropicContentBlock{
+			{Type: "text", Text: "先读文件"},
+			{Type: "tool_use", ID: "call_1", Name: "Read", Input: json.RawMessage(`{"path":"README.md"}`)},
+		},
+		StopReason: &stopReason,
+		Usage:      &AnthropicUsage{InputTokens: 10, OutputTokens: 5},
+	})
+
+	if got := resp.Choices[0].Message["content"]; got != "先读文件" {
+		t.Fatalf("content = %#v", got)
+	}
+	toolCalls, ok := resp.Choices[0].Message["tool_calls"].([]OpenAIChatToolCall)
+	if !ok || len(toolCalls) != 1 {
+		t.Fatalf("tool_calls = %#v", resp.Choices[0].Message["tool_calls"])
+	}
+	if resp.Choices[0].FinishReason == nil || *resp.Choices[0].FinishReason != "tool_calls" {
+		t.Fatalf("finish_reason = %#v", resp.Choices[0].FinishReason)
+	}
+	if resp.Usage["total_tokens"] != 15 {
+		t.Fatalf("usage = %#v", resp.Usage)
+	}
+}
+
+func TestOpenAIChatStreamTranscoder_EmitsToolCallsAndDone(t *testing.T) {
+	rr := httptest.NewRecorder()
+	transcoder := newOpenAIChatStreamTranscoder(rr, rr, "chatcmpl_test", "gpt-5.4", 123, true)
+	frames := []anthropicSSEFrame{
+		{Event: "message_start", Data: json.RawMessage(`{"message":{"usage":{"input_tokens":11}}}`)},
+		{Event: "content_block_start", Data: json.RawMessage(`{"index":0,"content_block":{"type":"tool_use","id":"call_1","name":"Read","input":{}}}`)},
+		{Event: "content_block_delta", Data: json.RawMessage(`{"index":0,"delta":{"type":"input_json_delta","partial_json":"{\"path\":\"README.md\"}"}}`)},
+		{Event: "message_delta", Data: json.RawMessage(`{"delta":{"stop_reason":"tool_use"},"usage":{"output_tokens":7}}`)},
+		{Event: "message_stop", Data: json.RawMessage(`{"type":"message_stop"}`)},
+	}
+	for _, frame := range frames {
+		if err := transcoder.HandleFrame(frame); err != nil {
+			t.Fatalf("HandleFrame(%s) error = %v", frame.Event, err)
+		}
+	}
+	body := rr.Body.String()
+	if !strings.Contains(body, "chat.completion.chunk") {
+		t.Fatalf("body missing chat.completion.chunk: %s", body)
+	}
+	if !strings.Contains(body, `"tool_calls"`) || !strings.Contains(body, `README.md`) {
+		t.Fatalf("body missing tool call data: %s", body)
+	}
+	if !strings.Contains(body, `"usage":{`) || !strings.Contains(body, `"prompt_tokens":11`) || !strings.Contains(body, `"completion_tokens":7`) || !strings.Contains(body, `"total_tokens":18`) {
+		t.Fatalf("body missing usage chunk: %s", body)
+	}
+	if !strings.Contains(body, "data: [DONE]") {
+		t.Fatalf("body missing DONE: %s", body)
+	}
+}
+
+func TestOpenAIResponsesStreamTranscoder_EmitsCompletedResponse(t *testing.T) {
+	rr := httptest.NewRecorder()
+	transcoder := newOpenAIResponsesStreamTranscoder(rr, rr, "resp_test", "gpt-5.4", 456)
+	frames := []anthropicSSEFrame{
+		{Event: "message_start", Data: json.RawMessage(`{"message":{"usage":{"input_tokens":9}}}`)},
+		{Event: "content_block_delta", Data: json.RawMessage(`{"index":0,"delta":{"type":"text_delta","text":"你好"}}`)},
+		{Event: "content_block_start", Data: json.RawMessage(`{"index":1,"content_block":{"type":"tool_use","id":"call_2","name":"Read","input":{}}}`)},
+		{Event: "content_block_delta", Data: json.RawMessage(`{"index":1,"delta":{"type":"input_json_delta","partial_json":"{\"path\":\"a.txt\"}"}}`)},
+		{Event: "content_block_stop", Data: json.RawMessage(`{"index":1}`)},
+		{Event: "message_delta", Data: json.RawMessage(`{"delta":{"stop_reason":"tool_use"},"usage":{"output_tokens":6}}`)},
+	}
+	for _, frame := range frames {
+		if err := transcoder.HandleFrame(frame); err != nil {
+			t.Fatalf("HandleFrame(%s) error = %v", frame.Event, err)
+		}
+	}
+	body := rr.Body.String()
+	if !strings.Contains(body, "event: response.created") {
+		t.Fatalf("missing response.created: %s", body)
+	}
+	if !strings.Contains(body, "event: response.output_text.delta") || !strings.Contains(body, "你好") {
+		t.Fatalf("missing text delta: %s", body)
+	}
+	if !strings.Contains(body, "event: response.function_call_arguments.delta") || !strings.Contains(body, `a.txt`) {
+		t.Fatalf("missing function_call_arguments.delta: %s", body)
+	}
+	if !strings.Contains(body, "event: response.completed") {
+		t.Fatalf("missing response.completed: %s", body)
+	}
+}


### PR DESCRIPTION
## 背景

当前仓库已经兼容 Anthropic Messages API（`POST /v1/messages`），
但很多现有客户端和 SDK 默认走 OpenAI 风格接口：

- `POST /v1/chat/completions`
- `POST /v1/responses`
- `GET /v1/models`

这导致现有能力虽然已经具备多账号、会话粘连、工具桥、文件上传等完整链路，
但 OpenAI 客户端不能直接接入，或者会在模型探测阶段因为缺少 `/v1/models` 而直接判定服务不可用。

这个 PR 的目标是补齐 OpenAI 兼容入口，并尽量复用现有稳定的 `/v1/messages` 主链，
避免重新实现一套独立推理逻辑。

## 主要改动

1. 新增 OpenAI 兼容入口
   - `POST /v1/chat/completions`
   - `POST /v1/responses`
   - `GET /v1/models`
   - `GET /models`

2. 新增协议桥接层
   - 新增 `internal/proxy/openai.go`
   - 将 OpenAI Chat Completions / Responses 请求转换为内部统一消息结构
   - 复用现有多账号选路、会话绑定、failover、工具桥、文件上传和 usage 聚合逻辑

3. 新增公开模型发现接口
   - 新增 `HandlePublicModels`
   - 输出 OpenAI 风格 `object=list` / `data[]` 模型列表
   - 返回归一化后的友好模型 ID，继续复用现有 `ResolveModel()` 主链
   - `/models` 作为 `/v1/models` 的兼容别名

4. 鉴权与路由更新
   - `/models` 现在也纳入 API key 鉴权
   - 启动日志补充 OpenAI models 端点
   - 新增 `cmd/notion-manager/main_test.go` 覆盖路由与鉴权

5. 支持的能力
   - 非流式 / 流式响应
   - `tools` / `function_call`
   - `response_format.json_schema`
   - `response_format.json_object`
   - Responses 的 `text.format`
   - 图片与文件输入（URL / data URL / inline data）

## 兼容边界

当前这版是基于现有代理能力做的 OpenAI 兼容桥，已明确处理以下边界：

- `/v1/responses` 当前为无状态桥接，暂不支持 `previous_response_id`
- 未实现 OpenAI Files API 资源层，因此不支持通过 `file_id` / 图片 `file_id` 取文件
- 当前仅支持 `function` 类型工具，不包含 OpenAI 官方托管的非 function built-in tools
- `/v1/models` 返回的是归一化友好模型名，不直接暴露 Notion 内部模型 ID

## 测试

已在本地执行：

```bash
timeout 60s go test ./internal/proxy
timeout 60s go test ./cmd/notion-manager
timeout 60s go test ./...
```

结果通过。
