### PR TITLE
fix(proxy): 修复 Notion Web 代理登录会话

### DIFF
--- a/internal/proxy/dashboard.go
+++ b/internal/proxy/dashboard.go
@@ -202,7 +202,7 @@ func (p *AccountPool) GetBestAccount() *Account {
 // CreateTargetedSession creates a proxy session for a specific account
 func (rp *ReverseProxy) CreateTargetedSession(w http.ResponseWriter, acc *Account) {
 	id := generateUUIDv4()
-	sess := &ProxySession{Account: acc, CreatedAt: time.Now()}
+	sess := newProxySession(acc)
 	rp.sessions.Store(id, sess)
 	http.SetCookie(w, &http.Cookie{
 		Name: "np_session", Value: id, Path: "/",

--- a/internal/proxy/reverseproxy.go
+++ b/internal/proxy/reverseproxy.go
@@ -36,13 +36,14 @@ var reAllowedMsgstoreHost = regexp.MustCompile(`(?i)^msgstore(?:-[a-z0-9-]+)?\.(
 type ProxySession struct {
 	Account   *Account
 	CreatedAt time.Time
+	CookieJar http.CookieJar
 }
 
 // ReverseProxy proxies requests to notion.so with session/cookie injection
 type ReverseProxy struct {
-	pool      *AccountPool
-	sessions  sync.Map     // sessionID → *ProxySession
-	msgClient *http.Client // shared client for msgstore (connection reuse required)
+	pool         *AccountPool
+	sessions     sync.Map // sessionID → *ProxySession
+	msgTransport http.RoundTripper
 }
 
 // NewReverseProxy creates a reverse proxy backed by the given account pool
@@ -50,44 +51,60 @@ func NewReverseProxy(pool *AccountPool) *ReverseProxy {
 	return &ReverseProxy{
 		pool: pool,
 		// Engine.IO requires sticky sessions: AWS ALB uses AWSALBAPP-0 cookie.
-		// CookieJar stores these cookies so subsequent requests hit the same backend.
+		// Each ProxySession's CookieJar stores those cookies independently while
+		// this transport remains shared for connection reuse.
 		// DialContext routes through AppConfig.Proxy.NotionProxy at dial
 		// time so a /admin/settings flip applies to new msgstore
 		// connections without restarting the process.
-		msgClient: func() *http.Client {
-			jar, _ := cookiejar.New(nil)
-			return &http.Client{
-				Jar:           jar,
-				CheckRedirect: reverseProxyCheckRedirect(nil),
-				Transport: &http.Transport{
-					DialContext: func(ctx context.Context, network, addr string) (net.Conn, error) {
-						return netutil.DialThroughProxy(ctx, network, addr, AppConfig.NotionProxyURL())
-					},
-					ForceAttemptHTTP2:   false,
-					TLSNextProto:        make(map[string]func(authority string, c *tls.Conn) http.RoundTripper),
-					MaxIdleConnsPerHost: 10,
-					IdleConnTimeout:     90 * time.Second,
-				},
-			}
-		}(),
+		msgTransport: &http.Transport{
+			DialContext: func(ctx context.Context, network, addr string) (net.Conn, error) {
+				return netutil.DialThroughProxy(ctx, network, addr, AppConfig.NotionProxyURL())
+			},
+			ForceAttemptHTTP2:   false,
+			TLSNextProto:        make(map[string]func(authority string, c *tls.Conn) http.RoundTripper),
+			MaxIdleConnsPerHost: 10,
+			IdleConnTimeout:     90 * time.Second,
+		},
 	}
 }
 
-// accountCookieHeader returns the original full cookie when available and a
-// safely serialized minimum Notion cookie set for token-only accounts.
-func accountCookieHeader(acc *Account) string {
+func newProxySession(acc *Account) *ProxySession {
+	jar, _ := cookiejar.New(nil)
+	return &ProxySession{
+		Account:   acc,
+		CreatedAt: time.Now(),
+		CookieJar: jar,
+	}
+}
+
+var safeFullCookieSeeds = map[string]bool{
+	"notion_check_cookie_consent":  true,
+	"notion_cookie_sync_completed": true,
+	"notion_locale":                true,
+}
+
+func isTransientSessionCookie(name string) bool {
+	name = strings.ToLower(strings.TrimSpace(name))
+	return strings.Contains(name, "sync_session") || strings.HasPrefix(name, "session_sync_")
+}
+
+func parseCookieHeader(raw string) []*http.Cookie {
+	if strings.TrimSpace(raw) == "" {
+		return nil
+	}
+	req := &http.Request{Header: make(http.Header)}
+	req.Header.Set("Cookie", raw)
+	return req.Cookies()
+}
+
+func accountSeedCookies(acc *Account) []*http.Cookie {
 	if acc == nil {
-		return ""
+		return nil
 	}
 
 	acc.mu.RLock()
 	defer acc.mu.RUnlock()
 
-	if acc.FullCookie != "" {
-		return acc.FullCookie
-	}
-
-	// Fallback: set minimal required cookies
 	values := []struct {
 		name  string
 		value string
@@ -97,29 +114,87 @@ func accountCookieHeader(acc *Account) string {
 		{name: "notion_browser_id", value: acc.BrowserID},
 		{name: "device_id", value: acc.DeviceID},
 	}
-	cookies := make([]string, 0, len(values))
+	cookies := make([]*http.Cookie, 0, len(values)+len(safeFullCookieSeeds))
+	seen := make(map[string]bool, len(values)+len(safeFullCookieSeeds))
 	for _, item := range values {
 		if item.value == "" {
 			continue
 		}
-		cookies = append(cookies, (&http.Cookie{Name: item.name, Value: item.value}).String())
+		cookies = append(cookies, &http.Cookie{Name: item.name, Value: item.value})
+		seen[item.name] = true
 	}
-	return strings.Join(cookies, "; ")
+
+	// FullCookie can contain stale session-sync state. Only copy explicitly
+	// stable, non-authentication preferences; Account fields above remain the
+	// source of truth, so token_v2 and identity cookies can never be replaced.
+	for _, cookie := range parseCookieHeader(acc.FullCookie) {
+		name := strings.ToLower(cookie.Name)
+		if isTransientSessionCookie(name) || !safeFullCookieSeeds[name] || seen[name] {
+			continue
+		}
+		cookies = append(cookies, &http.Cookie{Name: cookie.Name, Value: cookie.Value})
+		seen[name] = true
+	}
+	return cookies
 }
 
-func reverseProxyHTTPClient(timeout time.Duration, acc *Account) *http.Client {
-	return newReverseProxyHTTPClient(timeout, getChromeRoundTripper(), acc)
+// accountCookieHeader returns the stable Notion cookie seed for an account.
+func accountCookieHeader(acc *Account) string {
+	cookies := accountSeedCookies(acc)
+	parts := make([]string, 0, len(cookies))
+	for _, cookie := range cookies {
+		parts = append(parts, cookie.String())
+	}
+	return strings.Join(parts, "; ")
 }
 
-func newReverseProxyHTTPClient(timeout time.Duration, transport http.RoundTripper, acc *Account) *http.Client {
+func setProxySessionCookies(req *http.Request, sess *ProxySession) {
+	req.Header.Del("Cookie")
+	jarNames := make(map[string]bool)
+	if sess != nil && sess.CookieJar != nil {
+		for _, cookie := range sess.CookieJar.Cookies(req.URL) {
+			jarNames[cookie.Name] = true
+		}
+	}
+	if sess == nil {
+		return
+	}
+	for _, cookie := range accountSeedCookies(sess.Account) {
+		if !jarNames[cookie.Name] {
+			req.AddCookie(cookie)
+		}
+	}
+}
+
+func proxySessionCookieHeader(sess *ProxySession, targetURL *url.URL) string {
+	req := &http.Request{Header: make(http.Header), URL: targetURL}
+	setProxySessionCookies(req, sess)
+	if sess != nil && sess.CookieJar != nil {
+		for _, cookie := range sess.CookieJar.Cookies(targetURL) {
+			req.AddCookie(cookie)
+		}
+	}
+	return req.Header.Get("Cookie")
+}
+
+func reverseProxyHTTPClient(timeout time.Duration, sess *ProxySession) *http.Client {
+	return newReverseProxyHTTPClient(timeout, getChromeRoundTripper(), sess)
+}
+
+func newReverseProxyHTTPClient(timeout time.Duration, transport http.RoundTripper, sess *ProxySession) *http.Client {
+	var jar http.CookieJar
+	if sess != nil {
+		jar = sess.CookieJar
+	}
 	return &http.Client{
 		Transport:     transport,
 		Timeout:       timeout,
-		CheckRedirect: reverseProxyCheckRedirect(acc),
+		Jar:           jar,
+		CheckRedirect: reverseProxyCheckRedirect(sess),
 	}
 }
 
-func reverseProxyCheckRedirect(acc *Account) func(*http.Request, []*http.Request) error {
+func reverseProxyCheckRedirect(sess *ProxySession) func(*http.Request, []*http.Request) error {
 	return func(req *http.Request, via []*http.Request) error {
 		// The standard client may copy sensitive headers before CheckRedirect.
 		// Remove Cookie first so blocked destinations can never receive it.
@@ -138,13 +213,7 @@ func reverseProxyCheckRedirect(acc *Account) func(*http.Request, []*http.Request
 		}
 
 		req.Host = req.URL.Host
-		cookie := accountCookieHeader(acc)
-		if cookie == "" && len(via) != 0 {
-			cookie = via[0].Header.Get("Cookie")
-		}
-		if cookie != "" {
-			req.Header.Set("Cookie", cookie)
-		}
+		setProxySessionCookies(req, sess)
 		return nil
 	}
 }
@@ -334,10 +403,10 @@ func (rp *ReverseProxy) proxyHTML(w http.ResponseWriter, r *http.Request, sess *
 	if al := r.Header.Get("Accept-Language"); al != "" {
 		req.Header.Set("Accept-Language", al)
 	}
-	req.Header.Set("Cookie", accountCookieHeader(sess.Account))
+	setProxySessionCookies(req, sess)
 	// Deliberately omit Accept-Encoding so we get uncompressed HTML for patching
 
-	client := reverseProxyHTTPClient(30*time.Second, sess.Account)
+	client := reverseProxyHTTPClient(30*time.Second, sess)
 	resp, err := client.Do(req)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusBadGateway)
@@ -404,7 +473,7 @@ func (rp *ReverseProxy) proxyAPI(w http.ResponseWriter, r *http.Request, sess *P
 	}
 
 	acc := sess.Account
-	req.Header.Set("Cookie", accountCookieHeader(acc))
+	setProxySessionCookies(req, sess)
 	req.Header.Set("x-notion-active-user-header", acc.UserID)
 	req.Header.Set("x-notion-space-id", acc.SpaceID)
 	if acc.ClientVersion != "" {
@@ -414,7 +483,7 @@ func (rp *ReverseProxy) proxyAPI(w http.ResponseWriter, r *http.Request, sess *P
 	req.Header.Set("Referer", notionReferer)
 
 	// No timeout for streaming (runInferenceTranscript can stream for minutes)
-	client := reverseProxyHTTPClient(0, acc)
+	client := reverseProxyHTTPClient(0, sess)
 	resp, err := client.Do(req)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusBadGateway)
@@ -446,9 +515,9 @@ func (rp *ReverseProxy) proxyGeneric(w http.ResponseWriter, r *http.Request, ses
 			req.Header.Add(k, v)
 		}
 	}
-	req.Header.Set("Cookie", accountCookieHeader(sess.Account))
+	setProxySessionCookies(req, sess)
 
-	client := reverseProxyHTTPClient(30*time.Second, sess.Account)
+	client := reverseProxyHTTPClient(30*time.Second, sess)
 	resp, err := client.Do(req)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusBadGateway)
@@ -483,11 +552,11 @@ func (rp *ReverseProxy) proxyWithCookies(w http.ResponseWriter, r *http.Request,
 			req.Header.Add(k, v)
 		}
 	}
-	req.Header.Set("Cookie", accountCookieHeader(sess.Account))
+	setProxySessionCookies(req, sess)
 	req.Header.Set("Origin", notionOrigin)
 	req.Header.Set("Referer", notionReferer)
 
-	client := reverseProxyHTTPClient(0, sess.Account)
+	client := reverseProxyHTTPClient(0, sess)
 	resp, err := client.Do(req)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusBadGateway)
@@ -625,17 +694,9 @@ func (rp *ReverseProxy) proxyWebSocket(w http.ResponseWriter, r *http.Request, s
 			buf.WriteString(fmt.Sprintf("%s: %s\r\n", k, v))
 		}
 	}
-	// Include account cookies + ALB sticky session cookies from CookieJar
-	cookieStr := accountCookieHeader(sess.Account)
-	if rp.msgClient.Jar != nil {
-		jarURL, _ := url.Parse("https://" + targetHost + targetPath)
-		for _, c := range rp.msgClient.Jar.Cookies(jarURL) {
-			if cookieStr != "" {
-				cookieStr += "; "
-			}
-			cookieStr += c.String()
-		}
-	}
+	// Include account seeds plus this proxy session's dynamic and ALB cookies.
+	jarURL, _ := url.Parse("https://" + targetHost + targetPath)
+	cookieStr := proxySessionCookieHeader(sess, jarURL)
 	buf.WriteString(fmt.Sprintf("Cookie: %s\r\n", cookieStr))
 	buf.WriteString("Origin: " + notionOrigin + "\r\n")
 	buf.WriteString("\r\n")
@@ -654,6 +715,10 @@ func (rp *ReverseProxy) proxyWebSocket(w http.ResponseWriter, r *http.Request, s
 		clientConn.Write([]byte("HTTP/1.1 502 Bad Gateway\r\n\r\n"))
 		return
 	}
+	if sess.CookieJar != nil {
+		sess.CookieJar.SetCookies(jarURL, resp.Cookies())
+	}
+	resp.Header.Del("Set-Cookie")
 	resp.Write(clientConn)
 
 	if resp.StatusCode != http.StatusSwitchingProtocols {
@@ -703,12 +768,13 @@ func (rp *ReverseProxy) proxyMsgstoreHTTP(w http.ResponseWriter, r *http.Request
 			req.Header.Add(k, v)
 		}
 	}
-	req.Header.Set("Cookie", accountCookieHeader(sess.Account))
+	setProxySessionCookies(req, sess)
 	req.Header.Set("Origin", notionOrigin)
 	req.Header.Set("Referer", notionReferer)
 
-	// Use SHARED client with CookieJar — AWS ALB sticky session requires AWSALBAPP-0 cookie
-	resp, err := rp.msgClient.Do(req)
+	// The transport is shared for connection reuse; cookies remain session-local.
+	client := newReverseProxyHTTPClient(0, rp.msgTransport, sess)
+	resp, err := client.Do(req)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusBadGateway)
 		return

--- a/internal/proxy/reverseproxy.go
+++ b/internal/proxy/reverseproxy.go
@@ -20,12 +20,17 @@ import (
 )
 
 const (
-	notionOrigin   = "https://www.notion.so"
-	msgstoreOrigin = "https://msgstore.www.notion.so"
+	notionOrigin         = "https://app.notion.com"
+	notionReferer        = notionOrigin + "/"
+	msgstoreHost         = "msgstore.app.notion.com"
+	msgstoreOrigin       = "https://" + msgstoreHost
+	maxProxyRedirectHops = 3
 )
 
 // Strip analytics/tracking script/noscript tags from HTML
 var reAnalyticsScript = regexp.MustCompile(`(?s)<(?:script|noscript)[^>]*>.*?(?:googletagmanager\.com|customer\.io|gtag/js).*?</(?:script|noscript)>`)
+
+var reAllowedMsgstoreHost = regexp.MustCompile(`(?i)^msgstore(?:-[a-z0-9-]+)?\.(?:www\.notion\.so|app\.notion\.com)$`)
 
 // ProxySession maps a proxy session cookie to a pooled account
 type ProxySession struct {
@@ -52,7 +57,8 @@ func NewReverseProxy(pool *AccountPool) *ReverseProxy {
 		msgClient: func() *http.Client {
 			jar, _ := cookiejar.New(nil)
 			return &http.Client{
-				Jar: jar,
+				Jar:           jar,
+				CheckRedirect: reverseProxyCheckRedirect(nil),
 				Transport: &http.Transport{
 					DialContext: func(ctx context.Context, network, addr string) (net.Conn, error) {
 						return netutil.DialThroughProxy(ctx, network, addr, AppConfig.NotionProxyURL())
@@ -65,6 +71,86 @@ func NewReverseProxy(pool *AccountPool) *ReverseProxy {
 			}
 		}(),
 	}
+}
+
+// accountCookieHeader returns the original full cookie when available and a
+// safely serialized minimum Notion cookie set for token-only accounts.
+func accountCookieHeader(acc *Account) string {
+	if acc == nil {
+		return ""
+	}
+
+	acc.mu.RLock()
+	defer acc.mu.RUnlock()
+
+	if acc.FullCookie != "" {
+		return acc.FullCookie
+	}
+
+	// Fallback: set minimal required cookies
+	values := []struct {
+		name  string
+		value string
+	}{
+		{name: "token_v2", value: acc.TokenV2},
+		{name: "notion_user_id", value: acc.UserID},
+		{name: "notion_browser_id", value: acc.BrowserID},
+		{name: "device_id", value: acc.DeviceID},
+	}
+	cookies := make([]string, 0, len(values))
+	for _, item := range values {
+		if item.value == "" {
+			continue
+		}
+		cookies = append(cookies, (&http.Cookie{Name: item.name, Value: item.value}).String())
+	}
+	return strings.Join(cookies, "; ")
+}
+
+func reverseProxyHTTPClient(timeout time.Duration, acc *Account) *http.Client {
+	return newReverseProxyHTTPClient(timeout, getChromeRoundTripper(), acc)
+}
+
+func newReverseProxyHTTPClient(timeout time.Duration, transport http.RoundTripper, acc *Account) *http.Client {
+	return &http.Client{
+		Transport:     transport,
+		Timeout:       timeout,
+		CheckRedirect: reverseProxyCheckRedirect(acc),
+	}
+}
+
+func reverseProxyCheckRedirect(acc *Account) func(*http.Request, []*http.Request) error {
+	return func(req *http.Request, via []*http.Request) error {
+		// The standard client may copy sensitive headers before CheckRedirect.
+		// Remove Cookie first so blocked destinations can never receive it.
+		req.Header.Del("Cookie")
+
+		if len(via) > maxProxyRedirectHops {
+			return fmt.Errorf("reverse proxy redirect limit exceeded: %d hops", maxProxyRedirectHops)
+		}
+		if req.URL.Scheme != "https" || !isAllowedNotionRedirectHost(req.URL.Hostname()) {
+			return fmt.Errorf("reverse proxy redirect blocked: %s", req.URL.Redacted())
+		}
+		for _, previous := range via {
+			if previous.URL.String() == req.URL.String() {
+				return fmt.Errorf("reverse proxy redirect loop blocked: %s", req.URL.Redacted())
+			}
+		}
+
+		req.Host = req.URL.Host
+		cookie := accountCookieHeader(acc)
+		if cookie == "" && len(via) != 0 {
+			cookie = via[0].Header.Get("Cookie")
+		}
+		if cookie != "" {
+			req.Header.Set("Cookie", cookie)
+		}
+		return nil
+	}
+}
+
+func isAllowedNotionRedirectHost(host string) bool {
+	return strings.EqualFold(host, "www.notion.so") || strings.EqualFold(host, "app.notion.com")
 }
 
 // getSession retrieves an existing session for the request.
@@ -86,22 +172,11 @@ func (rp *ReverseProxy) getSession(r *http.Request) *ProxySession {
 func configPatchScript(origin string, acc *Account) string {
 	// Build cookie-setting JS from full_cookie string
 	cookieJS := ""
-	if acc.FullCookie != "" {
-		for _, part := range strings.Split(acc.FullCookie, "; ") {
-			part = strings.TrimSpace(part)
-			if part != "" {
-				cookieJS += fmt.Sprintf(`document.cookie=%q+";path=/";`, part)
-			}
+	for _, part := range strings.Split(accountCookieHeader(acc), ";") {
+		part = strings.TrimSpace(part)
+		if part != "" {
+			cookieJS += fmt.Sprintf(`document.cookie=%q+";path=/";`, part)
 		}
-	} else {
-		// Fallback: set minimal required cookies
-		cookieJS = fmt.Sprintf(
-			`document.cookie="token_v2=%s;path=/";`+
-				`document.cookie="notion_user_id=%s;path=/";`+
-				`document.cookie="notion_browser_id=%s;path=/";`+
-				`document.cookie="device_id=%s;path=/";`,
-			acc.TokenV2, acc.UserID, acc.BrowserID, acc.DeviceID,
-		)
 	}
 
 	return fmt.Sprintf(`<script>(function(){`+
@@ -121,8 +196,8 @@ func configPatchScript(origin string, acc *Account) string {
 		`if(navigator.serviceWorker)navigator.serviceWorker.getRegistrations()`+
 		`.then(function(r){r.forEach(function(x){x.unregister()})});`+
 		// Step 4: Intercept fetch/XHR/WebSocket for msgstore URLs
-		`var re=/https?:\/\/(msgstore[^\/]*\.www\.notion\.so)/;`+
-		`var wre=/wss?:\/\/(msgstore[^\/]*\.www\.notion\.so)/;`+
+		`var re=/https?:\/\/(msgstore[^\/]*\.(?:www\.notion\.so|app\.notion\.com))/;`+
+		`var wre=/wss?:\/\/(msgstore[^\/]*\.(?:www\.notion\.so|app\.notion\.com))/;`+
 		`var _bk=/googletagmanager\.com|customer\.io|app\.notion\.com\/exp|splunkcloud\.com|amplitude\.com/;`+
 		`var _f=window.fetch;`+
 		`window.fetch=function(u,i){`+
@@ -200,7 +275,7 @@ func (rp *ReverseProxy) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	// MessageStore proxy (real-time sync)
 	// Primus strips path from messageStore.url and uses origin + /primus-v8/
 	if strings.HasPrefix(path, "/primus-v8/") || strings.HasPrefix(path, "/msgstore/") {
-		targetHost := "msgstore.www.notion.so"
+		targetHost := msgstoreHost
 		targetPath := path
 		if strings.HasPrefix(path, "/msgstore/") {
 			targetPath = strings.TrimPrefix(path, "/msgstore")
@@ -259,10 +334,10 @@ func (rp *ReverseProxy) proxyHTML(w http.ResponseWriter, r *http.Request, sess *
 	if al := r.Header.Get("Accept-Language"); al != "" {
 		req.Header.Set("Accept-Language", al)
 	}
-	req.Header.Set("Cookie", sess.Account.FullCookie)
+	req.Header.Set("Cookie", accountCookieHeader(sess.Account))
 	// Deliberately omit Accept-Encoding so we get uncompressed HTML for patching
 
-	client := getChromeHTTPClient(30 * time.Second)
+	client := reverseProxyHTTPClient(30*time.Second, sess.Account)
 	resp, err := client.Do(req)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusBadGateway)
@@ -329,17 +404,17 @@ func (rp *ReverseProxy) proxyAPI(w http.ResponseWriter, r *http.Request, sess *P
 	}
 
 	acc := sess.Account
-	req.Header.Set("Cookie", acc.FullCookie)
+	req.Header.Set("Cookie", accountCookieHeader(acc))
 	req.Header.Set("x-notion-active-user-header", acc.UserID)
 	req.Header.Set("x-notion-space-id", acc.SpaceID)
 	if acc.ClientVersion != "" {
 		req.Header.Set("notion-client-version", acc.ClientVersion)
 	}
-	req.Header.Set("Origin", "https://www.notion.so")
-	req.Header.Set("Referer", "https://www.notion.so/")
+	req.Header.Set("Origin", notionOrigin)
+	req.Header.Set("Referer", notionReferer)
 
 	// No timeout for streaming (runInferenceTranscript can stream for minutes)
-	client := getChromeHTTPClient(0)
+	client := reverseProxyHTTPClient(0, acc)
 	resp, err := client.Do(req)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusBadGateway)
@@ -371,9 +446,9 @@ func (rp *ReverseProxy) proxyGeneric(w http.ResponseWriter, r *http.Request, ses
 			req.Header.Add(k, v)
 		}
 	}
-	req.Header.Set("Cookie", sess.Account.FullCookie)
+	req.Header.Set("Cookie", accountCookieHeader(sess.Account))
 
-	client := getChromeHTTPClient(30 * time.Second)
+	client := reverseProxyHTTPClient(30*time.Second, sess.Account)
 	resp, err := client.Do(req)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusBadGateway)
@@ -408,11 +483,11 @@ func (rp *ReverseProxy) proxyWithCookies(w http.ResponseWriter, r *http.Request,
 			req.Header.Add(k, v)
 		}
 	}
-	req.Header.Set("Cookie", sess.Account.FullCookie)
-	req.Header.Set("Origin", "https://www.notion.so")
-	req.Header.Set("Referer", "https://www.notion.so/")
+	req.Header.Set("Cookie", accountCookieHeader(sess.Account))
+	req.Header.Set("Origin", notionOrigin)
+	req.Header.Set("Referer", notionReferer)
 
-	client := getChromeHTTPClient(0)
+	client := reverseProxyHTTPClient(0, sess.Account)
 	resp, err := client.Do(req)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusBadGateway)
@@ -486,8 +561,17 @@ func isWebSocketUpgrade(r *http.Request) bool {
 	return strings.EqualFold(r.Header.Get("Upgrade"), "websocket")
 }
 
+func isAllowedMsgstoreHost(host string) bool {
+	return reAllowedMsgstoreHost.MatchString(host)
+}
+
 // proxyWebSocket does TCP-level WebSocket proxying via HTTP hijack
 func (rp *ReverseProxy) proxyWebSocket(w http.ResponseWriter, r *http.Request, sess *ProxySession, targetHost, targetPath string) {
+	if !isAllowedMsgstoreHost(targetHost) {
+		http.Error(w, "invalid msgstore host", http.StatusBadRequest)
+		return
+	}
+
 	hj, ok := w.(http.Hijacker)
 	if !ok {
 		http.Error(w, "websocket not supported", http.StatusInternalServerError)
@@ -542,15 +626,18 @@ func (rp *ReverseProxy) proxyWebSocket(w http.ResponseWriter, r *http.Request, s
 		}
 	}
 	// Include account cookies + ALB sticky session cookies from CookieJar
-	cookieStr := sess.Account.FullCookie
+	cookieStr := accountCookieHeader(sess.Account)
 	if rp.msgClient.Jar != nil {
 		jarURL, _ := url.Parse("https://" + targetHost + targetPath)
 		for _, c := range rp.msgClient.Jar.Cookies(jarURL) {
-			cookieStr += "; " + c.Name + "=" + c.Value
+			if cookieStr != "" {
+				cookieStr += "; "
+			}
+			cookieStr += c.String()
 		}
 	}
 	buf.WriteString(fmt.Sprintf("Cookie: %s\r\n", cookieStr))
-	buf.WriteString("Origin: https://www.notion.so\r\n")
+	buf.WriteString("Origin: " + notionOrigin + "\r\n")
 	buf.WriteString("\r\n")
 
 	if _, err := targetConn.Write([]byte(buf.String())); err != nil {
@@ -591,6 +678,11 @@ func (rp *ReverseProxy) proxyWebSocket(w http.ResponseWriter, r *http.Request, s
 
 // proxyMsgstoreHTTP proxies msgstore HTTP requests using the shared persistent client
 func (rp *ReverseProxy) proxyMsgstoreHTTP(w http.ResponseWriter, r *http.Request, sess *ProxySession, targetHost, targetPath string) {
+	if !isAllowedMsgstoreHost(targetHost) {
+		http.Error(w, "invalid msgstore host", http.StatusBadRequest)
+		return
+	}
+
 	targetURL := "https://" + targetHost + targetPath
 	if r.URL.RawQuery != "" {
 		targetURL += "?" + r.URL.RawQuery
@@ -611,9 +703,9 @@ func (rp *ReverseProxy) proxyMsgstoreHTTP(w http.ResponseWriter, r *http.Request
 			req.Header.Add(k, v)
 		}
 	}
-	req.Header.Set("Cookie", sess.Account.FullCookie)
-	req.Header.Set("Origin", "https://www.notion.so")
-	req.Header.Set("Referer", "https://www.notion.so/")
+	req.Header.Set("Cookie", accountCookieHeader(sess.Account))
+	req.Header.Set("Origin", notionOrigin)
+	req.Header.Set("Referer", notionReferer)
 
 	// Use SHARED client with CookieJar — AWS ALB sticky session requires AWSALBAPP-0 cookie
 	resp, err := rp.msgClient.Do(req)

--- a/internal/proxy/reverseproxy.go
+++ b/internal/proxy/reverseproxy.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"context"
 	"crypto/tls"
+	"encoding/json"
 	"fmt"
 	"io"
 	"log"
@@ -111,6 +112,7 @@ func accountSeedCookies(acc *Account) []*http.Cookie {
 	}{
 		{name: "token_v2", value: acc.TokenV2},
 		{name: "notion_user_id", value: acc.UserID},
+		{name: "notion_users", value: notionUsersCookieValue(acc.UserID)},
 		{name: "notion_browser_id", value: acc.BrowserID},
 		{name: "device_id", value: acc.DeviceID},
 	}
@@ -136,6 +138,17 @@ func accountSeedCookies(acc *Account) []*http.Cookie {
 		seen[name] = true
 	}
 	return cookies
+}
+
+func notionUsersCookieValue(userID string) string {
+	if userID == "" {
+		return ""
+	}
+	users, err := json.Marshal([]string{userID})
+	if err != nil {
+		return ""
+	}
+	return url.PathEscape(string(users))
 }
 
 // accountCookieHeader returns the stable Notion cookie seed for an account.

--- a/internal/proxy/reverseproxy_test.go
+++ b/internal/proxy/reverseproxy_test.go
@@ -46,7 +46,8 @@ func TestAccountCookieHeaderFallback(t *testing.T) {
 		BrowserID: "browser",
 		DeviceID:  "device",
 	}
-	want := "token_v2=token; notion_user_id=user; notion_browser_id=browser; device_id=device"
+	want := "token_v2=token; notion_user_id=user; notion_users=%5B%22user%22%5D; " +
+		"notion_browser_id=browser; device_id=device"
 	if got := accountCookieHeader(acc); got != want {
 		t.Fatalf("accountCookieHeader() = %q, want %q", got, want)
 	}
@@ -58,12 +59,12 @@ func TestAccountCookieHeaderFiltersFullCookieAndKeepsStableSeeds(t *testing.T) {
 		UserID:    "stable-user",
 		BrowserID: "stable-browser",
 		DeviceID:  "stable-device",
-		FullCookie: "token_v2=stale-token; notion_user_id=stale-user; notion_locale=zh-CN; " +
+		FullCookie: "token_v2=stale-token; notion_user_id=stale-user; notion_users=%5B%22stale-user%22%5D; notion_locale=zh-CN; " +
 			"notion_check_cookie_consent=true; sync_session=stale; sync_session_v2=stale; " +
 			"session_sync_nonce=stale; session_sync_checked=stale; custom=value",
 	}
-	want := "token_v2=stable-token; notion_user_id=stable-user; notion_browser_id=stable-browser; " +
-		"device_id=stable-device; notion_locale=zh-CN; notion_check_cookie_consent=true"
+	want := "token_v2=stable-token; notion_user_id=stable-user; notion_users=%5B%22stable-user%22%5D; " +
+		"notion_browser_id=stable-browser; device_id=stable-device; notion_locale=zh-CN; notion_check_cookie_consent=true"
 	if got := accountCookieHeader(acc); got != want {
 		t.Fatalf("accountCookieHeader() = %q, want %q", got, want)
 	}

--- a/internal/proxy/reverseproxy_test.go
+++ b/internal/proxy/reverseproxy_test.go
@@ -4,6 +4,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"strings"
 	"testing"
 )
@@ -26,6 +27,18 @@ func reverseProxyResponse(status int, location string) *http.Response {
 	}
 }
 
+func cookieValues(header, name string) []string {
+	req := &http.Request{Header: make(http.Header)}
+	req.Header.Set("Cookie", header)
+	var values []string
+	for _, cookie := range req.Cookies() {
+		if cookie.Name == name {
+			values = append(values, cookie.Value)
+		}
+	}
+	return values
+}
+
 func TestAccountCookieHeaderFallback(t *testing.T) {
 	acc := &Account{
 		TokenV2:   "token",
@@ -39,16 +52,25 @@ func TestAccountCookieHeaderFallback(t *testing.T) {
 	}
 }
 
-func TestAccountCookieHeaderPreservesFullCookie(t *testing.T) {
-	const fullCookie = "token_v2=full; custom=value; spaced=kept exactly"
-	acc := &Account{TokenV2: "fallback", FullCookie: fullCookie}
-	if got := accountCookieHeader(acc); got != fullCookie {
-		t.Fatalf("accountCookieHeader() = %q, want exact FullCookie %q", got, fullCookie)
+func TestAccountCookieHeaderFiltersFullCookieAndKeepsStableSeeds(t *testing.T) {
+	acc := &Account{
+		TokenV2:   "stable-token",
+		UserID:    "stable-user",
+		BrowserID: "stable-browser",
+		DeviceID:  "stable-device",
+		FullCookie: "token_v2=stale-token; notion_user_id=stale-user; notion_locale=zh-CN; " +
+			"notion_check_cookie_consent=true; sync_session=stale; sync_session_v2=stale; " +
+			"session_sync_nonce=stale; session_sync_checked=stale; custom=value",
+	}
+	want := "token_v2=stable-token; notion_user_id=stable-user; notion_browser_id=stable-browser; " +
+		"device_id=stable-device; notion_locale=zh-CN; notion_check_cookie_consent=true"
+	if got := accountCookieHeader(acc); got != want {
+		t.Fatalf("accountCookieHeader() = %q, want %q", got, want)
 	}
 }
 
 func TestReverseProxyRedirectReinjectsCookieAndUpdatesHost(t *testing.T) {
-	acc := &Account{TokenV2: "token"}
+	sess := newProxySession(&Account{TokenV2: "token"})
 	var requests []*http.Request
 	transport := reverseProxyRoundTripper(func(req *http.Request) (*http.Response, error) {
 		requests = append(requests, req.Clone(req.Context()))
@@ -62,8 +84,8 @@ func TestReverseProxyRedirectReinjectsCookieAndUpdatesHost(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	req.Header.Set("Cookie", accountCookieHeader(acc))
-	resp, err := newReverseProxyHTTPClient(0, transport, acc).Do(req)
+	setProxySessionCookies(req, sess)
+	resp, err := newReverseProxyHTTPClient(0, transport, sess).Do(req)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -80,8 +102,116 @@ func TestReverseProxyRedirectReinjectsCookieAndUpdatesHost(t *testing.T) {
 	}
 }
 
+func TestReverseProxyRedirectPersistsIntermediateCookie(t *testing.T) {
+	sess := newProxySession(&Account{TokenV2: "token"})
+	var requests []*http.Request
+	transport := reverseProxyRoundTripper(func(req *http.Request) (*http.Response, error) {
+		requests = append(requests, req.Clone(req.Context()))
+		if len(requests) == 1 {
+			resp := reverseProxyResponse(http.StatusTemporaryRedirect, "https://app.notion.com/space/sessionSyncCallback")
+			resp.Header.Add("Set-Cookie", "sync_session=dynamic; Path=/; Secure; HttpOnly")
+			return resp, nil
+		}
+		return reverseProxyResponse(http.StatusOK, ""), nil
+	})
+
+	req, err := http.NewRequest(http.MethodGet, "https://app.notion.com/ai", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	setProxySessionCookies(req, sess)
+	resp, err := newReverseProxyHTTPClient(0, transport, sess).Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp.Body.Close()
+
+	if len(requests) != 2 {
+		t.Fatalf("requests = %d, want 2", len(requests))
+	}
+	if got := cookieValues(requests[1].Header.Get("Cookie"), "sync_session"); len(got) != 1 || got[0] != "dynamic" {
+		t.Fatalf("redirect sync_session cookies = %v, want [dynamic]", got)
+	}
+}
+
+func TestReverseProxyFinalCookiePersistsAcrossRequests(t *testing.T) {
+	sess := newProxySession(&Account{TokenV2: "token"})
+	var requests []*http.Request
+	transport := reverseProxyRoundTripper(func(req *http.Request) (*http.Response, error) {
+		requests = append(requests, req.Clone(req.Context()))
+		resp := reverseProxyResponse(http.StatusOK, "")
+		if len(requests) == 1 {
+			resp.Header.Add("Set-Cookie", "session_sync_checked=true; Path=/; Secure; HttpOnly")
+		}
+		return resp, nil
+	})
+
+	for _, path := range []string{"/ai", "/api/v3/loadUserContent"} {
+		req, err := http.NewRequest(http.MethodGet, "https://app.notion.com"+path, nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+		setProxySessionCookies(req, sess)
+		resp, err := newReverseProxyHTTPClient(0, transport, sess).Do(req)
+		if err != nil {
+			t.Fatal(err)
+		}
+		resp.Body.Close()
+	}
+
+	if got := cookieValues(requests[1].Header.Get("Cookie"), "session_sync_checked"); len(got) != 1 || got[0] != "true" {
+		t.Fatalf("second request session_sync_checked cookies = %v, want [true]", got)
+	}
+}
+
+func TestReverseProxyJarCookieOverridesSeedWithoutDuplicate(t *testing.T) {
+	sess := newProxySession(&Account{TokenV2: "seed-token"})
+	var requests []*http.Request
+	transport := reverseProxyRoundTripper(func(req *http.Request) (*http.Response, error) {
+		requests = append(requests, req.Clone(req.Context()))
+		if len(requests) == 1 {
+			resp := reverseProxyResponse(http.StatusTemporaryRedirect, "/callback")
+			resp.Header.Add("Set-Cookie", "token_v2=jar-token; Path=/; Secure; HttpOnly")
+			return resp, nil
+		}
+		return reverseProxyResponse(http.StatusOK, ""), nil
+	})
+
+	req, err := http.NewRequest(http.MethodGet, "https://app.notion.com/ai", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	setProxySessionCookies(req, sess)
+	resp, err := newReverseProxyHTTPClient(0, transport, sess).Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp.Body.Close()
+
+	if got := cookieValues(requests[1].Header.Get("Cookie"), "token_v2"); len(got) != 1 || got[0] != "jar-token" {
+		t.Fatalf("redirect token_v2 cookies = %v, want exactly [jar-token]", got)
+	}
+}
+
+func TestReverseProxyCookieJarsAreIsolated(t *testing.T) {
+	url, err := url.Parse("https://app.notion.com/ai")
+	if err != nil {
+		t.Fatal(err)
+	}
+	sessA := newProxySession(&Account{TokenV2: "token"})
+	sessB := newProxySession(&Account{TokenV2: "token"})
+	sessA.CookieJar.SetCookies(url, []*http.Cookie{{Name: "sync_session", Value: "session-a", Path: "/", Secure: true}})
+
+	if got := cookieValues(proxySessionCookieHeader(sessA, url), "sync_session"); len(got) != 1 || got[0] != "session-a" {
+		t.Fatalf("session A sync_session cookies = %v, want [session-a]", got)
+	}
+	if got := cookieValues(proxySessionCookieHeader(sessB, url), "sync_session"); len(got) != 0 {
+		t.Fatalf("session B unexpectedly received session A cookies: %v", got)
+	}
+}
+
 func TestReverseProxyRedirectBlocksUnknownHostWithoutRequest(t *testing.T) {
-	acc := &Account{TokenV2: "secret"}
+	sess := newProxySession(&Account{TokenV2: "secret"})
 	requests := 0
 	evilRequests := 0
 	transport := reverseProxyRoundTripper(func(req *http.Request) (*http.Response, error) {
@@ -99,8 +229,8 @@ func TestReverseProxyRedirectBlocksUnknownHostWithoutRequest(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	req.Header.Set("Cookie", accountCookieHeader(acc))
-	_, err = newReverseProxyHTTPClient(0, transport, acc).Do(req)
+	setProxySessionCookies(req, sess)
+	_, err = newReverseProxyHTTPClient(0, transport, sess).Do(req)
 	if err == nil {
 		t.Fatal("unknown redirect unexpectedly succeeded")
 	}
@@ -120,7 +250,9 @@ func TestReverseProxyRedirectLimit(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	_, err = newReverseProxyHTTPClient(0, transport, &Account{TokenV2: "token"}).Do(req)
+	sess := newProxySession(&Account{TokenV2: "token"})
+	setProxySessionCookies(req, sess)
+	_, err = newReverseProxyHTTPClient(0, transport, sess).Do(req)
 	if err == nil {
 		t.Fatal("redirect chain unexpectedly succeeded")
 	}
@@ -145,10 +277,41 @@ func TestProxyMsgstoreRejectsUntrustedHostBeforeRequest(t *testing.T) {
 	recorder := httptest.NewRecorder()
 	request := httptest.NewRequest(http.MethodGet, "/capture", nil)
 	rp := &ReverseProxy{}
-	rp.proxyMsgstoreHTTP(recorder, request, &ProxySession{Account: &Account{TokenV2: "secret"}}, "attacker.example", "/capture")
+	rp.proxyMsgstoreHTTP(recorder, request, newProxySession(&Account{TokenV2: "secret"}), "attacker.example", "/capture")
 
 	if recorder.Code != http.StatusBadRequest {
 		t.Fatalf("status = %d, want %d", recorder.Code, http.StatusBadRequest)
+	}
+}
+
+func TestProxyMsgstoreHTTPUsesSessionCookieJar(t *testing.T) {
+	sess := newProxySession(&Account{TokenV2: "token"})
+	var requests []*http.Request
+	rp := &ReverseProxy{
+		msgTransport: reverseProxyRoundTripper(func(req *http.Request) (*http.Response, error) {
+			requests = append(requests, req.Clone(req.Context()))
+			resp := reverseProxyResponse(http.StatusOK, "")
+			if len(requests) == 1 {
+				resp.Header.Add("Set-Cookie", "AWSALBAPP-0=sticky; Path=/; Secure; HttpOnly")
+			}
+			return resp, nil
+		}),
+	}
+
+	for range 2 {
+		recorder := httptest.NewRecorder()
+		request := httptest.NewRequest(http.MethodGet, "/primus-v8/", nil)
+		rp.proxyMsgstoreHTTP(recorder, request, sess, msgstoreHost, "/primus-v8/")
+		if recorder.Code != http.StatusOK {
+			t.Fatalf("msgstore status = %d, want %d", recorder.Code, http.StatusOK)
+		}
+		if got := recorder.Header().Values("Set-Cookie"); len(got) != 0 {
+			t.Fatalf("browser received upstream Set-Cookie: %v", got)
+		}
+	}
+
+	if got := cookieValues(requests[1].Header.Get("Cookie"), "AWSALBAPP-0"); len(got) != 1 || got[0] != "sticky" {
+		t.Fatalf("second msgstore request sticky cookies = %v, want [sticky]", got)
 	}
 }
 

--- a/internal/proxy/reverseproxy_test.go
+++ b/internal/proxy/reverseproxy_test.go
@@ -1,0 +1,170 @@
+package proxy
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+type reverseProxyRoundTripper func(*http.Request) (*http.Response, error)
+
+func (f reverseProxyRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req)
+}
+
+func reverseProxyResponse(status int, location string) *http.Response {
+	header := make(http.Header)
+	if location != "" {
+		header.Set("Location", location)
+	}
+	return &http.Response{
+		StatusCode: status,
+		Header:     header,
+		Body:       io.NopCloser(strings.NewReader("")),
+	}
+}
+
+func TestAccountCookieHeaderFallback(t *testing.T) {
+	acc := &Account{
+		TokenV2:   "token",
+		UserID:    "user",
+		BrowserID: "browser",
+		DeviceID:  "device",
+	}
+	want := "token_v2=token; notion_user_id=user; notion_browser_id=browser; device_id=device"
+	if got := accountCookieHeader(acc); got != want {
+		t.Fatalf("accountCookieHeader() = %q, want %q", got, want)
+	}
+}
+
+func TestAccountCookieHeaderPreservesFullCookie(t *testing.T) {
+	const fullCookie = "token_v2=full; custom=value; spaced=kept exactly"
+	acc := &Account{TokenV2: "fallback", FullCookie: fullCookie}
+	if got := accountCookieHeader(acc); got != fullCookie {
+		t.Fatalf("accountCookieHeader() = %q, want exact FullCookie %q", got, fullCookie)
+	}
+}
+
+func TestReverseProxyRedirectReinjectsCookieAndUpdatesHost(t *testing.T) {
+	acc := &Account{TokenV2: "token"}
+	var requests []*http.Request
+	transport := reverseProxyRoundTripper(func(req *http.Request) (*http.Response, error) {
+		requests = append(requests, req.Clone(req.Context()))
+		if len(requests) == 1 {
+			return reverseProxyResponse(http.StatusTemporaryRedirect, "https://app.notion.com/space/sessionSyncCallback"), nil
+		}
+		return reverseProxyResponse(http.StatusOK, ""), nil
+	})
+
+	req, err := http.NewRequest(http.MethodGet, "https://www.notion.so/sessionSyncCallback", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	req.Header.Set("Cookie", accountCookieHeader(acc))
+	resp, err := newReverseProxyHTTPClient(0, transport, acc).Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp.Body.Close()
+
+	if len(requests) != 2 {
+		t.Fatalf("requests = %d, want 2", len(requests))
+	}
+	if got := requests[1].Host; got != "app.notion.com" {
+		t.Fatalf("redirect Host = %q, want app.notion.com", got)
+	}
+	if got := requests[1].Header.Get("Cookie"); got != "token_v2=token" {
+		t.Fatalf("redirect Cookie = %q, want token fallback", got)
+	}
+}
+
+func TestReverseProxyRedirectBlocksUnknownHostWithoutRequest(t *testing.T) {
+	acc := &Account{TokenV2: "secret"}
+	requests := 0
+	evilRequests := 0
+	transport := reverseProxyRoundTripper(func(req *http.Request) (*http.Response, error) {
+		requests++
+		if req.URL.Hostname() == "evil.example" {
+			evilRequests++
+			if req.Header.Get("Cookie") != "" {
+				t.Fatal("cookie leaked to blocked redirect host")
+			}
+		}
+		return reverseProxyResponse(http.StatusFound, "https://evil.example/steal"), nil
+	})
+
+	req, err := http.NewRequest(http.MethodGet, "https://www.notion.so/start", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	req.Header.Set("Cookie", accountCookieHeader(acc))
+	_, err = newReverseProxyHTTPClient(0, transport, acc).Do(req)
+	if err == nil {
+		t.Fatal("unknown redirect unexpectedly succeeded")
+	}
+	if requests != 1 || evilRequests != 0 {
+		t.Fatalf("requests = %d, evil requests = %d; want 1 and 0", requests, evilRequests)
+	}
+}
+
+func TestReverseProxyRedirectLimit(t *testing.T) {
+	requests := 0
+	transport := reverseProxyRoundTripper(func(req *http.Request) (*http.Response, error) {
+		requests++
+		return reverseProxyResponse(http.StatusFound, "/hop/"+string(rune('0'+requests))), nil
+	})
+
+	req, err := http.NewRequest(http.MethodGet, "https://app.notion.com/start", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = newReverseProxyHTTPClient(0, transport, &Account{TokenV2: "token"}).Do(req)
+	if err == nil {
+		t.Fatal("redirect chain unexpectedly succeeded")
+	}
+	if requests != maxProxyRedirectHops+1 {
+		t.Fatalf("requests = %d, want %d", requests, maxProxyRedirectHops+1)
+	}
+}
+
+func TestConfigPatchRewritesAppMsgstore(t *testing.T) {
+	script := configPatchScript("https://proxy.example", &Account{TokenV2: "token"})
+	for _, domain := range []string{`www\.notion\.so`, `app\.notion\.com`} {
+		if !strings.Contains(script, domain) {
+			t.Fatalf("config patch does not support msgstore domain %q", domain)
+		}
+	}
+	if msgstoreOrigin != "https://msgstore.app.notion.com" {
+		t.Fatalf("msgstoreOrigin = %q, want canonical app host", msgstoreOrigin)
+	}
+}
+
+func TestProxyMsgstoreRejectsUntrustedHostBeforeRequest(t *testing.T) {
+	recorder := httptest.NewRecorder()
+	request := httptest.NewRequest(http.MethodGet, "/capture", nil)
+	rp := &ReverseProxy{}
+	rp.proxyMsgstoreHTTP(recorder, request, &ProxySession{Account: &Account{TokenV2: "secret"}}, "attacker.example", "/capture")
+
+	if recorder.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want %d", recorder.Code, http.StatusBadRequest)
+	}
+}
+
+func TestAllowedMsgstoreHosts(t *testing.T) {
+	tests := map[string]bool{
+		"msgstore.www.notion.so":          true,
+		"msgstore-001.www.notion.so":      true,
+		"msgstore.app.notion.com":         true,
+		"msgstore-002.app.notion.com":     true,
+		"attacker.example":                false,
+		"msgstore.app.notion.com.evil":    false,
+		"msgstore-001.app.notion.com:443": false,
+	}
+	for host, want := range tests {
+		if got := isAllowedMsgstoreHost(host); got != want {
+			t.Errorf("isAllowedMsgstoreHost(%q) = %v, want %v", host, got, want)
+		}
+	}
+}


### PR DESCRIPTION
## 问题

Notion Web 代理在当前 `www.notion.so -> app.notion.com` 会话同步流程下会出现两类登录故障：

- 服务端自动追随跨域重定向时丢失认证 Cookie，可能触发 `sessionSyncCallback` 重定向循环。
- 新浏览器 origin 缺少 `notion_users`，前端无法解析当前用户，会在请求 `loadUserContent` 前直接跳转登录页。

此外，动态 `sync_session*` Cookie 若不按代理会话持久化，会导致首次 HTML 成功、后续 API 再次失去认证。

## 修复

- 将 Notion canonical origin 更新为 `app.notion.com`，只允许受信任 Notion 域名且最多 3 跳的重定向。
- 为每个 `ProxySession` 建立独立 CookieJar，持久化中间和最终响应 Cookie，并保持账号间隔离。
- 从当前 `Account.UserID` 派生单用户 `notion_users` Cookie，不复用 `FullCookie` 中可能过期的多账号状态。
- msgstore 仅共享 Transport，不共享 CookieJar；同时限制允许的 msgstore host，避免认证信息被带到任意目标。
- 增加重定向、Cookie 持久化/覆盖/隔离和 msgstore 安全回归测试。

## 验证

- `go test -count=1 ./...`
- `go vet ./...`
- `go test -race -count=1 ./internal/proxy -run 'Test(AccountCookieHeader|ConfigPatch|ReverseProxyRedirect|ProxyMsgstore)'`
- 实际 Docker 部署全新浏览器会话验证：`/proxy/start?best=true` 最终停留 `/ai`，显示 Notion AI 和工作区，未再跳转 `/login`。
